### PR TITLE
rework build task to only run a single CROWN build task

### DIFF
--- a/lawluigi_configs/GPU_example_law.cfg
+++ b/lawluigi_configs/GPU_example_law.cfg
@@ -20,7 +20,7 @@ job_file_dir_cleanup: False
 default_wlcg_fs = wlcg_fs
 
 [wlcg_fs]
-base: srm://cmssrm-kit.gridka.de:8443/srm/managerv2?SFN=/pnfs/gridka.de/cms/disk-only/store/user/${USER}/LAW_storage
+base: root://cmsxrootd-kit.gridka.de//store/user/${USER}/LAW_storage
 use_cache: True
 cache_root: /tmp/$USER/
 cache_max_size: 20000

--- a/lawluigi_configs/GPU_example_luigi.cfg
+++ b/lawluigi_configs/GPU_example_luigi.cfg
@@ -46,5 +46,4 @@ htcondor_request_memory = 1000
 htcondor_requirements = ( TARGET.CloudSite =?= "topas" )
 # && (Machine =?= "f03-001-179-e.gridka.de")
 htcondor_request_disk = 1000000
-replace_processor_tar = True
 [ReadFromRemote]

--- a/lawluigi_configs/GPU_example_luigi.cfg
+++ b/lawluigi_configs/GPU_example_luigi.cfg
@@ -14,7 +14,7 @@ ENV_NAME = ML_LAW
 
 ; grid storage protocol and path usable from submitting machine and worker nodes of cluster
 ; job in- and output will be stored in $wlcg_path under subdirectory of analysis $name
-wlcg_path = srm://cmssrm-kit.gridka.de:8443/srm/managerv2?SFN=/pnfs/gridka.de/cms/disk-only/store/user/${USER}/LAW_storage
+wlcg_path = root://cmsxrootd-kit.gridka.de//store/user/${USER}/LAW_storage
 ; default htcondor job submission configuration (modifiable for each task)
 htcondor_accounting_group = cms.higgs
 htcondor_remote_job = True

--- a/lawluigi_configs/KingMaker_law.cfg
+++ b/lawluigi_configs/KingMaker_law.cfg
@@ -17,12 +17,14 @@ max_reschedules: 3
 [job]
 job_file_dir = $ANALYSIS_DATA_PATH/jobs
 job_file_dir_cleanup: False
+job_file_dir_mkdtemp: True
 
 [target]
 default_wlcg_fs = wlcg_fs
 
 [wlcg_fs]
-base: srm://cmssrm-kit.gridka.de:8443/srm/managerv2?SFN=/pnfs/gridka.de/cms/disk-only/store/user/${USER}/CROWN_samples
+base: root://cmsxrootd-kit.gridka.de//store/user/${USER}/CROWN_samples
 use_cache: True
 cache_root: /tmp/$USER/
 cache_max_size: 20000
+gfal_atomic_contexts: True

--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -1,6 +1,6 @@
 [core]
 no_lock = True
-log_level = DEBUG
+log_level = WARNING
 
 [worker]
 keep_alive = False
@@ -14,7 +14,7 @@ ENV_NAME = KingMaker
 
 ; grid storage protocol and path usable from submitting machine and worker nodes of cluster
 ; job in- and output will be stored in $wlcg_path under subdirectory of analysis $name
-wlcg_path = srm://cmssrm-kit.gridka.de:8443/srm/managerv2?SFN=/pnfs/gridka.de/cms/disk-only/store/user/${USER}/CROWN_samples
+wlcg_path = root://cmsxrootd-kit.gridka.de//store/user/${USER}/CROWN_samples
 ; default htcondor job submission configuration (modifiable for each task)
 htcondor_accounting_group = cms.higgs
 htcondor_remote_job = True
@@ -39,7 +39,7 @@ only_missing = True
 ; bootstrap file to be sourced at beginning of htcondor jobs (relative PATH to framework.py)
 bootstrap_file = setup_law_remote.sh
 
-scopes = ["et"]
+scopes = ["mm"]
 shifts = None
 
 [CROWNBuild]

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -182,8 +182,6 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
         tarball = law.wlcg.WLCGFileTarget(
             "{tag}/{task}/job_tarball/processor.tar.gz".format(
                 tag=self.production_tag,
-                            tag=self.production_tag, 
-                tag=self.production_tag,
                 task=self.__class__.__name__
             )
         )

--- a/processor/setup_law_remote.sh
+++ b/processor/setup_law_remote.sh
@@ -8,6 +8,13 @@ action(){
         [ ! -z "$1" ] && export PATH="$1:${PATH}" && echo "Add $1 to PATH"
     }
 
+    echo "------------------------------------------"
+    echo " | HOSTNAME = $(hostname)"
+    echo " | ANA_NAME = ${ANA_NAME}"
+    echo " | ENV_NAME = ${ENV_NAME}"
+    echo " | TARBALL_PATH = ${TARBALL_PATH}"
+    echo "------------------------------------------"
+
     # Setup variables
     SPAWNPOINT=$(pwd)
 
@@ -22,10 +29,7 @@ action(){
 
     # on ETP ressources, this is not needed, since we can use a docker image containing the conda environment
     # on other systems, these changes here might be needed
-    echo "------------------------------------------"
-    echo " | ANA_NAME = ${ANA_NAME}"
-    echo " | ENV_NAME = ${ENV_NAME}"
-    echo " | TARBALL_PATH = ${TARBALL_PATH}"
+
     if [[ ! -z "${ENV_FROM_TAR}" ]]; then
         ENV_PATH=${SPAWNPOINT}/miniconda/envs/${ENV_NAME}
         echo " | ENV_PATH = $ENV_PATH"
@@ -34,7 +38,6 @@ action(){
         ENV_PATH=/cvmfs/etp.kit.edu/LAW_envs/${ENV_NAME}
         echo " | ENV_PATH = ${ENV_PATH}"
     fi
-    echo "------------------------------------------"
 
     # copy and untar process (and environment if necessary) 
     if [[ -z "${ENV_FROM_TAR}" ]]; then

--- a/processor/setup_law_remote.sh
+++ b/processor/setup_law_remote.sh
@@ -45,15 +45,15 @@ action(){
     if [[ -z "${ENV_FROM_TAR}" ]]; then
         # Activate environment from cvmfs
         source ${ENV_PATH}/bin/activate
-        echo "xrdcp ${TARBALL_PATH} ${SPAWNPOINT}"
-        xrdcp ${TARBALL_PATH} ${SPAWNPOINT}
+        echo "gfal-copy ${TARBALL_PATH} ${SPAWNPOINT}"
+        gfal-copy ${TARBALL_PATH} ${SPAWNPOINT}
     else
         (
             source /cvmfs/grid.cern.ch/umd-c7ui-latest/etc/profile.d/setup-c7-ui-example.sh
-            echo "xrdcp ${TARBALL_PATH} ${SPAWNPOINT}"
-            xrdcp ${TARBALL_PATH} ${SPAWNPOINT}
-            echo "xrdcp ${TARBALL_ENV_PATH} ${SPAWNPOINT}"
-            xrdcp ${TARBALL_ENV_PATH} ${SPAWNPOINT}
+            echo "gfal-copy ${TARBALL_PATH} ${SPAWNPOINT}"
+            gfal-copy ${TARBALL_PATH} ${SPAWNPOINT}
+            echo "gfal-copy ${TARBALL_ENV_PATH} ${SPAWNPOINT}"
+            gfal-copy ${TARBALL_ENV_PATH} ${SPAWNPOINT}
         )
         mkdir -p ${ENV_PATH}
         tar -xzf ${ENV_NAME}_env.tar.gz -C ${ENV_PATH} && rm ${ENV_NAME}_env.tar.gz

--- a/processor/setup_law_remote.sh
+++ b/processor/setup_law_remote.sh
@@ -9,11 +9,12 @@ action(){
     }
 
     echo "------------------------------------------"
+    echo " | USER = ${USER}"
     echo " | HOSTNAME = $(hostname)"
     echo " | ANA_NAME = ${ANA_NAME}"
     echo " | ENV_NAME = ${ENV_NAME}"
+    echo " | TAG = ${TAG}"
     echo " | TARBALL_PATH = ${TARBALL_PATH}"
-    echo "------------------------------------------"
 
     # Setup variables
     SPAWNPOINT=$(pwd)
@@ -38,17 +39,21 @@ action(){
         ENV_PATH=/cvmfs/etp.kit.edu/LAW_envs/${ENV_NAME}
         echo " | ENV_PATH = ${ENV_PATH}"
     fi
+    echo "------------------------------------------"
 
     # copy and untar process (and environment if necessary) 
     if [[ -z "${ENV_FROM_TAR}" ]]; then
         # Activate environment from cvmfs
         source ${ENV_PATH}/bin/activate
-        gfal-copy ${TARBALL_PATH} ${SPAWNPOINT}
+        echo "xrdcp ${TARBALL_PATH} ${SPAWNPOINT}"
+        xrdcp ${TARBALL_PATH} ${SPAWNPOINT}
     else
         (
             source /cvmfs/grid.cern.ch/umd-c7ui-latest/etc/profile.d/setup-c7-ui-example.sh
-            gfal-copy ${TARBALL_PATH} ${SPAWNPOINT}
-            gfal-copy ${TARBALL_ENV_PATH} ${SPAWNPOINT}
+            echo "xrdcp ${TARBALL_PATH} ${SPAWNPOINT}"
+            xrdcp ${TARBALL_PATH} ${SPAWNPOINT}
+            echo "xrdcp ${TARBALL_ENV_PATH} ${SPAWNPOINT}"
+            xrdcp ${TARBALL_ENV_PATH} ${SPAWNPOINT}
         )
         mkdir -p ${ENV_PATH}
         tar -xzf ${ENV_NAME}_env.tar.gz -C ${ENV_PATH} && rm ${ENV_NAME}_env.tar.gz
@@ -57,7 +62,7 @@ action(){
         conda-unpack
     fi
 
-    tar -xzf ${ANA_NAME}_processor.tar.gz && rm ${ANA_NAME}_processor.tar.gz
+    tar -xzf processor.tar.gz && rm processor.tar.gz
 
     # (
     #     source /cvmfs/grid.cern.ch/umd-c7ui-latest/etc/profile.d/setup-c7-ui-example.sh

--- a/processor/tasks/CROWNBuild.py
+++ b/processor/tasks/CROWNBuild.py
@@ -19,14 +19,13 @@ class CROWNBuild(Task):
     eras = luigi.ListParameter()
     sampletypes = luigi.ListParameter()
     analysis = luigi.Parameter()
-    production_tag = luigi.Parameter()
 
     env_script = os.path.join(
         os.path.dirname(__file__), "../../", "setup", "setup_crown_cmake.sh"
     )
 
     def output(self):
-        target = self.remote_target("crown_{}_{}.tar.gz".format(self.analysis, self.production_tag)
+        target = self.remote_target("crown_{}.tar.gz".format(self.analysis)
         )
         return target
 
@@ -45,7 +44,7 @@ class CROWNBuild(Task):
         _scopes = ",".join(self.scopes)
         _analysis = str(self.analysis)
         _shifts = str(self.shifts)
-        _tag = "{}/CROWN_{}".format(self.production_tag, _analysis)
+        _tag = "CROWN_{}".format(_analysis)
         _install_dir = os.path.join(str(self.install_dir), _tag)
         _build_dir = os.path.join(str(self.build_dir), _tag)
         _crown_path = os.path.abspath("CROWN")

--- a/processor/tasks/CROWNBuild.py
+++ b/processor/tasks/CROWNBuild.py
@@ -26,16 +26,13 @@ class CROWNBuild(Task):
     )
 
     def output(self):
-        target = self.remote_target(
-            "{}/crown_{}.tar.gz".format(self.production_tag, self.analysis)
+        target = self.remote_target("crown_{}_{}.tar.gz".format(self.analysis, self.production_tag)
         )
-        target.parent.touch()
         return target
 
     def run(self):
         # get output file path
         output = self.output()
-        output.parent.touch()
         # convert list to comma separated strings
         if len(self.sampletypes) == 1:
             _sampletypes = self.sampletypes[0]
@@ -48,7 +45,7 @@ class CROWNBuild(Task):
         _scopes = ",".join(self.scopes)
         _analysis = str(self.analysis)
         _shifts = str(self.shifts)
-        _tag = "CROWN_{}".format(_analysis)
+        _tag = "{}/CROWN_{}".format(self.production_tag, _analysis)
         _install_dir = os.path.join(str(self.install_dir), _tag)
         _build_dir = os.path.join(str(self.build_dir), _tag)
         _crown_path = os.path.abspath("CROWN")
@@ -139,5 +136,7 @@ class CROWNBuild(Task):
                     os.path.join(_install_dir, output.basename)
                 )
             )
+            output.parent.touch()
+            console.log("Copying to remote: {}".format(output.path))
             output.copy_from_local(os.path.join(_install_dir, output.basename))
         console.rule("Finished CROWNRun")

--- a/processor/tasks/CROWNBuild.py
+++ b/processor/tasks/CROWNBuild.py
@@ -44,7 +44,7 @@ class CROWNBuild(Task):
         _scopes = ",".join(self.scopes)
         _analysis = str(self.analysis)
         _shifts = str(self.shifts)
-        _tag = "CROWN_{}".format(_analysis)
+        _tag = "{}/CROWN_{}".format(self.production_tag, _analysis)
         _install_dir = os.path.join(str(self.install_dir), _tag)
         _build_dir = os.path.join(str(self.build_dir), _tag)
         _crown_path = os.path.abspath("CROWN")

--- a/processor/tasks/CROWNBuild.py
+++ b/processor/tasks/CROWNBuild.py
@@ -19,14 +19,14 @@ class CROWNBuild(Task):
     eras = luigi.ListParameter()
     sampletypes = luigi.ListParameter()
     analysis = luigi.Parameter()
+    production_tag = luigi.Parameter()
 
     env_script = os.path.join(
         os.path.dirname(__file__), "../../", "setup", "setup_crown_cmake.sh"
     )
 
     def output(self):
-        target = self.remote_target("crown_{}.tar.gz".format(self.analysis)
-        )
+        target = self.remote_target("crown_{}.tar.gz".format(self.analysis))
         return target
 
     def run(self):
@@ -44,6 +44,7 @@ class CROWNBuild(Task):
         _scopes = ",".join(self.scopes)
         _analysis = str(self.analysis)
         _shifts = str(self.shifts)
+        # also use the tag for the local tarball creation
         _tag = "{}/CROWN_{}".format(self.production_tag, _analysis)
         _install_dir = os.path.join(str(self.install_dir), _tag)
         _build_dir = os.path.join(str(self.build_dir), _tag)
@@ -119,10 +120,12 @@ class CROWNBuild(Task):
                 for line in p.stdout:
                     if line != "\n":
                         console.log(line.replace("\n", ""))
+                for line in p.stderr:
+                    if line != "\n":
+                        console.log(line.replace("\n", ""))
 
             if p.returncode != 0:
                 console.log("Error when building crown {}".format(command))
-                console.log("Output: {}".format(p.stderr))
                 console.log(
                     "building returned non-zero exit status {}".format(p.returncode)
                 )

--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -31,7 +31,6 @@ class CROWNRun(Task, HTCondorWorkflow, law.LocalWorkflow):
     era = luigi.Parameter()
     eras = luigi.ListParameter()
     analysis = luigi.Parameter()
-    production_tag = luigi.Parameter()
     files_per_task = luigi.IntParameter(default=1)
 
     def modify_polling_status_line(self, status_line):
@@ -43,13 +42,11 @@ class CROWNRun(Task, HTCondorWorkflow, law.LocalWorkflow):
     def workflow_requires(self):
         requirements = super(CROWNRun, self).workflow_requires()
         requirements["datasetinfo"] = ConfigureDatasets.req(self)
-        requirements["tarball"] = CROWNBuild.req(
-            self, production_tag=self.production_tag
-        )
+        requirements["tarball"] = CROWNBuild.req(self)
         return requirements
 
     def requires(self):
-        return {"tarball": CROWNBuild.req(self, production_tag=self.production_tag)}
+        return {"tarball": CROWNBuild.req(self)}
 
     def create_branch_map(self):
         dataset = ConfigureDatasets(nick=self.nick)
@@ -65,8 +62,7 @@ class CROWNRun(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     def output(self):
         nicks = [
-            "{tag}/{nick}/ntuple_{nick}_{branch}_{scope}.root".format(
-                tag=self.production_tag,
+            "{nick}/ntuple_{nick}_{branch}_{scope}.root".format(
                 nick=self.nick,
                 branch=self.branch,
                 scope=scope,

--- a/processor/tasks/ConfigureDatasets.py
+++ b/processor/tasks/ConfigureDatasets.py
@@ -1,4 +1,3 @@
-import law
 import luigi
 import os
 import json

--- a/processor/tasks/ConfigureDatasets.py
+++ b/processor/tasks/ConfigureDatasets.py
@@ -21,6 +21,7 @@ class ConfigureDatasets(Task):
 
     nick = luigi.Parameter()
     dataset_database = luigi.Parameter()
+    production_tag = luigi.Parameter()
     env_script = os.path.join(
         os.path.dirname(__file__), "../../", "setup", "dasclient.sh"
     )
@@ -41,6 +42,10 @@ class ConfigureDatasets(Task):
             cmd, stdout=PIPE, stderr=PIPE, shell=True, env=self.my_env
         )
         # jsonS = code.communicate()[0]
+        if code != 0:
+            raise Exception(
+                "DAS query failed: {} \n Error: {}".format(das_query, error)
+            )
         filelist = json.loads(out)
         for file in filelist:
             filedict[file["file"][0]["name"]] = file["file"][0]["nevents"]
@@ -55,11 +60,11 @@ class ConfigureDatasets(Task):
 
     def output(self):
         target = self.remote_target("sample_database/{}.yaml".format(self.nick))
-        target.parent.touch()
         return target
 
     def run(self):
         output = self.output()
+        output.parent.touch()
         if not output.exists():
             # set environment variables
             self.my_env = self.set_environment(self.env_script)
@@ -79,6 +84,7 @@ class ConfigureDatasets(Task):
             console.rule("Nick: {}".format(self.nick))
             # if the filelist is already there, load it
             if os.path.exists(sample_configfile):
+                print("Loading sample config file")
                 with open(sample_configfile, "r") as stream:
                     try:
                         sample_data = yaml.safe_load(stream)

--- a/processor/tasks/MinimalRemoteExample.py
+++ b/processor/tasks/MinimalRemoteExample.py
@@ -34,7 +34,7 @@ class RunRemote(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     # Output target is remote and accessed using gfal2.
     def output(self):
-        target = self.remote_target("RemoteFileChanged.txt")
+        target = self.remote_target(self.production_tag, "RemoteFileChanged.txt")
         target.parent.touch()
         return target
 
@@ -44,8 +44,12 @@ class RunRemote(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     # Task is run remotely and has access to GPU resources.
     def run(self):
-        import tensorflow as tf
-        tf.test.is_gpu_available()
+        try:
+            import tensorflow as tf
+            tf.test.is_gpu_available()
+        except:
+            print("Tensorflow not found.")
+        os.listdir("tmp/")
         readText = self.input().load()
         self.publish_message("This is the input: {}".format(self.input()))
         wholeText = readText + "a triumph!"

--- a/processor/tasks/MinimalRemoteExample.py
+++ b/processor/tasks/MinimalRemoteExample.py
@@ -34,7 +34,7 @@ class RunRemote(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     # Output target is remote and accessed using gfal2.
     def output(self):
-        target = self.remote_target(self.production_tag, "RemoteFileChanged.txt")
+        target = self.remote_target("RemoteFileChanged.txt")
         target.parent.touch()
         return target
 
@@ -49,7 +49,6 @@ class RunRemote(Task, HTCondorWorkflow, law.LocalWorkflow):
             tf.test.is_gpu_available()
         except:
             print("Tensorflow not found.")
-        os.listdir("tmp/")
         readText = self.input().load()
         self.publish_message("This is the input: {}".format(self.input()))
         wholeText = readText + "a triumph!"

--- a/processor/tasks/ProduceSamples.py
+++ b/processor/tasks/ProduceSamples.py
@@ -13,6 +13,7 @@ class ProduceSamples(Task):
     sample_list = luigi.Parameter()
     analysis = luigi.Parameter()
     dataset_database = luigi.Parameter()
+    production_tag = luigi.Parameter()
 
     def requires(self):
         # load the list of samples to be processed

--- a/processor/tasks/ProduceSamples.py
+++ b/processor/tasks/ProduceSamples.py
@@ -13,7 +13,6 @@ class ProduceSamples(Task):
     sample_list = luigi.Parameter()
     analysis = luigi.Parameter()
     dataset_database = luigi.Parameter()
-    production_tag = luigi.Parameter()
 
     def requires(self):
         # load the list of samples to be processed

--- a/processor/tasks/compile_crown.sh
+++ b/processor/tasks/compile_crown.sh
@@ -11,7 +11,9 @@ SHIFTS=$6
 INSTALLDIR=$7
 BUILDDIR=$8
 TARBALLNAME=$9
-
+THREADS_AVAILABLE=$(grep -c ^processor /proc/cpuinfo)
+THREADS=$(( THREADS_AVAILABLE / 4 ))
+echo "Using $THREADS threads"
 which cmake
 
 cmake $CROWNFOLDER \
@@ -24,7 +26,10 @@ cmake $CROWNFOLDER \
  -B$BUILDDIR
 
 cd $BUILDDIR
-ninja install
+make install -j $THREADS
 cd $INSTALLDIR
 touch $TARBALLNAME
 tar -czvf $TARBALLNAME --exclude=$TARBALLNAME .
+echo "CROWN tarball created: $TARBALLNAME"
+
+exit 0

--- a/sample_database/datasets.yaml
+++ b/sample_database/datasets.yaml
@@ -1,31 +1,674 @@
-temp_nick:
-  campaign: RunIISummer20UL18NanoAODv2
-  datasetname: DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8
-  datatier: NANOAODSIM
-  dbs: /DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+# Data -> not tested yet, if this is working
+# mu tau channel
+DoubleMuon_Run2018A:
+  campaign: ""
+  datasetname: DoubleMuon_Run2018A-UL2018_MiniAODv2_NanoAODv9-v1
+  datatier: NANOAOD
+  dbs: /DoubleMuon/Run2018A-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD
   energy: 13
   era: 2018
-  extension: ''
-  generators: amcatnloFXFX-pythia8
-  nevents: 85259315
-  nfiles: 85
-  prepid: SMP-RunIISummer20UL18NanoAODv2-00030
-  sample_type: mc
+  extension: ""
+  generators: ""
+  nevents: 241613524
+  nfiles: 164
+  prepid: ReReco-Run2018A-DoubleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
   status: VALID
-  version: 1
-temp_nick_2:
-  campaign: RunIISummer20UL18NanoAODv2
-  datasetname: DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8
-  datatier: NANOAODSIM
-  dbs: /DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  version: 2
+DoubleMuon_Run2018B:
+  campaign: ""
+  datasetname: DoubleMuon_Run2018B-UL2018_MiniAODv2_NanoAODv9-v1
+  datatier: NANOAOD
+  dbs: /DoubleMuon/Run2018B-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD
   energy: 13
   era: 2018
-  extension: ''
-  generators: amcatnloFXFX-pythia8
-  nevents: 85259315
-  nfiles: 85
-  prepid: SMP-RunIISummer20UL18NanoAODv2-00030
-  sample_type: mc
+  extension: ""
+  generators: ""
+  nevents: 119918017
+  nfiles: 76
+  prepid: ReReco-Run2018B-DoubleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
+  status: VALID
+  version: 2
+DoubleMuon_Run2018C:
+  campaign: ""
+  datasetname: DoubleMuon_Run2018C-UL2018_MiniAODv2_NanoAODv9-v1
+  datatier: NANOAOD
+  dbs: /DoubleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 110032072
+  nfiles: 49
+  prepid: ReReco-Run2018C-DoubleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
+  status: VALID
+  version: 2
+DoubleMuon_Run2018D:
+  campaign: ""
+  datasetname: DoubleMuon_Run2018D-UL2018_MiniAODv2_NanoAODv9-v1
+  datatier: NANOAOD
+  dbs: /DoubleMuon/Run2018D-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 513909894
+  nfiles: 197
+  prepid: ReReco-Run2018D-DoubleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
+  status: VALID
+  version: 2
+DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 98433266
+  nfiles: 53
+  prepid: TAU-RunIISummer20UL18NanoAODv2-00001
+  sample_type: dy
   status: VALID
   version: 1
-
+DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer19UL18NanoAODv2
+  datasetname: DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer19UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 65679725
+  nfiles: 41
+  prepid: TAU-RunIISummer19UL18NanoAODv2-00004
+  sample_type: dy
+  status: VALID
+  version: 1
+DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer19UL18NanoAODv2
+  datasetname: DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer19UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 28280407
+  nfiles: 22
+  prepid: TAU-RunIISummer19UL18NanoAODv2-00005
+  sample_type: dy
+  status: VALID
+  version: 1
+DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer19UL18NanoAODv2
+  datasetname: DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer19UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 19021176
+  nfiles: 18
+  prepid: TAU-RunIISummer19UL18NanoAODv2-00006
+  sample_type: dy
+  status: VALID
+  version: 1
+DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer19UL18NanoAODv2
+  datasetname: DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer19UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 7581874
+  nfiles: 12
+  prepid: TAU-RunIISummer19UL18NanoAODv2-00007
+  sample_type: dy
+  status: VALID
+  version: 1
+DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 99449093
+  nfiles: 46
+  prepid: SUS-RunIISummer20UL18NanoAODv2-00007
+  sample_type: dy
+  status: VALID
+  version: 1
+# W + jets
+WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 83009353
+  nfiles: 45
+  prepid: BTV-RunIISummer20UL18NanoAODv2-00004
+  sample_type: wj
+  status: VALID
+  version: 1
+W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 47429123
+  nfiles: 25
+  prepid: BTV-RunIISummer20UL18NanoAODv2-00019
+  sample_type: wj
+  status: VALID
+  version: 1
+W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 28095849
+  nfiles: 60
+  prepid: BTV-RunIISummer20UL18NanoAODv2-00020
+  sample_type: wj
+  status: VALID
+  version: 1
+W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 18016072
+  nfiles: 39
+  prepid: BTV-RunIISummer20UL18NanoAODv2-00021
+  sample_type: wj
+  status: VALID
+  version: 1
+W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8
+  datatier: NANOAODSIM
+  dbs: /W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: madgraphMLM-pythia8
+  nevents: 9045482
+  nfiles: 43
+  prepid: BTV-RunIISummer20UL18NanoAODv2-00022
+  sample_type: wj
+  status: VALID
+  version: 1
+# ttbar
+TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8
+  datatier: NANOAODSIM
+  dbs: /TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg-pythia8
+  nevents: 148470000
+  nfiles: 181
+  prepid: TOP-RunIISummer20UL18NanoAODv2-00007
+  sample_type: tt
+  status: VALID
+  version: 1
+TTToHadronic_TuneCP5_13TeV-powheg-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: TTToHadronic_TuneCP5_13TeV-powheg-pythia8
+  datatier: NANOAODSIM
+  dbs: /TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg-pythia8
+  nevents: 344028000
+  nfiles: 343
+  prepid: TOP-RunIISummer20UL18NanoAODv2-00006
+  sample_type: tt
+  status: VALID
+  version: 1
+TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8
+  datatier: NANOAODSIM
+  dbs: /TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg-pythia8
+  nevents: 486770000
+  nfiles: 465
+  prepid: TOP-RunIISummer20UL18NanoAODv2-00005
+  sample_type: tt
+  status: VALID
+  version: 1
+# single top
+ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8:
+  campaign: RunIISummer19UL18NanoAODv2
+  datasetname: ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8
+  datatier: NANOAODSIM
+  dbs: /ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer19UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg-madspin-pythia8
+  nevents: 47707100
+  nfiles: 37
+  prepid: TOP-RunIISummer19UL18NanoAODv2-00009
+  sample_type: tt
+  status: VALID
+  version: 1
+ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8:
+  campaign: RunIISummer19UL18NanoAODv2
+  datasetname: ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8
+  datatier: NANOAODSIM
+  dbs: /ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer19UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg-madspin-pythia8
+  nevents: 23421300
+  nfiles: 30
+  prepid: TOP-RunIISummer19UL18NanoAODv2-00086
+  sample_type: tt
+  status: VALID
+  version: 1
+ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8
+  datatier: NANOAODSIM
+  dbs: /ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg-pythia8
+  nevents: 7804000
+  nfiles: 104
+  prepid: TOP-RunIISummer20UL18NanoAODv2-00071
+  sample_type: tt
+  status: VALID
+  version: 1
+ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8
+  datatier: NANOAODSIM
+  dbs: /ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg-pythia8
+  nevents: 7701000
+  nfiles: 107
+  prepid: TOP-RunIISummer20UL18NanoAODv2-00072
+  sample_type: tt
+  status: VALID
+  version: 1
+# Diboson dedicated
+WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8
+  datatier: NANOAODSIM
+  dbs: /WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: amcatnloFXFX-pythia8
+  nevents: 9678809
+  nfiles: 24
+  prepid: SMP-RunIISummer20UL18NanoAODv2-00070
+  sample_type: vv
+  status: VALID
+  version: 1
+ZZTo4L_TuneCP5_13TeV_powheg_pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: ZZTo4L_TuneCP5_13TeV_powheg_pythia8
+  datatier: NANOAODSIM
+  dbs: /ZZTo4L_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg_pythia8
+  nevents: 99218000
+  nfiles: 65
+  prepid: HIG-RunIISummer20UL18NanoAODv2-00099
+  sample_type: vv
+  status: VALID
+  version: 1
+ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8
+  datatier: NANOAODSIM
+  dbs: /ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg_pythia8
+  nevents: 56812000
+  nfiles: 35
+  prepid: SUS-RunIISummer20UL18NanoAODv2-00015
+  sample_type: vv
+  status: VALID
+  version: 1
+WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8
+  datatier: NANOAODSIM
+  dbs: /WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: powheg_pythia8
+  nevents: 9664000
+  nfiles: 48
+  prepid: SUS-RunIISummer20UL18NanoAODv2-00039
+  sample_type: vv
+  status: VALID
+  version: 1
+# Diboson inclusive
+WW_TuneCP5_13TeV-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: WW_TuneCP5_13TeV-pythia8
+  datatier: NANOAODSIM
+  dbs: /WW_TuneCP5_13TeV-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: pythia8
+  nevents: 15670000
+  nfiles: 21
+  prepid: BTV-RunIISummer20UL18NanoAODv2-00002
+  sample_type: vv
+  status: VALID
+  version: 1
+ZZ_TuneCP5_13TeV-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: ZZ_TuneCP5_13TeV-pythia8
+  datatier: NANOAODSIM
+  dbs: /ZZ_TuneCP5_13TeV-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: pythia8
+  nevents: 3907000
+  nfiles: 3
+  prepid: SUS-RunIISummer20UL18NanoAODv2-00014
+  sample_type: vv
+  status: VALID
+  version: 1
+WZ_TuneCP5_13TeV-pythia8:
+  campaign: RunIISummer20UL18NanoAODv2
+  datasetname: WZ_TuneCP5_13TeV-pythia8
+  datatier: NANOAODSIM
+  dbs: /WZ_TuneCP5_13TeV-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: pythia8
+  nevents: 7986000
+  nfiles: 21
+  prepid: BTV-RunIISummer20UL18NanoAODv2-00001
+  sample_type: vv
+  status: VALID
+  version: 1
+MuEmbedding_Run2018A:
+  campaign: ""
+  datasetname: MuEmbedding_Run2018A-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 208
+  nevents: 20764967
+MuEmbedding_Run2018B:
+  campaign: ""
+  datasetname: MuEmbedding_Run2018B-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 94
+  nevents: 9301733
+MuEmbedding_Run2018C:
+  campaign: ""
+  datasetname: MuEmbedding_Run2018C-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 86
+  nevents: 8566763
+MuEmbedding_Run2018D:
+  campaign: ""
+  datasetname: MuEmbedding_Run2018D-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 402
+  nevents: 40168375
+SingleMuon_Run2018A:
+  campaign: ""
+  datasetname: SingleMuon_Run2018A-UL2018_MiniAODv1_NanoAODv2-v2
+  datatier: NANOAOD
+  dbs: /SingleMuon/Run2018A-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 241608232
+  nfiles: 92
+  prepid: ReReco-Run2018A-SingleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
+  status: VALID
+  version: 2
+SingleMuon_Run2018B:
+  campaign: ""
+  datasetname: SingleMuon_Run2018B-UL2018_MiniAODv1_NanoAODv2-v2
+  datatier: NANOAOD
+  dbs: /SingleMuon/Run2018B-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 119918017
+  nfiles: 51
+  prepid: ReReco-Run2018B-SingleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
+  status: VALID
+  version: 2
+SingleMuon_Run2018C:
+  campaign: ""
+  datasetname: SingleMuon_Run2018C-UL2018_MiniAODv1_NanoAODv2-v2
+  datatier: NANOAOD
+  dbs: /SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9-v2/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 109986009
+  nfiles: 56
+  prepid: ReReco-Run2018C-SingleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
+  status: VALID
+  version: 2
+SingleMuon_Run2018D:
+  campaign: ""
+  datasetname: SingleMuon_Run2018D-UL2018_MiniAODv1_NanoAODv2-v2
+  datatier: NANOAOD
+  dbs: /SingleMuon/Run2018D-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 513909894
+  nfiles: 194
+  prepid: ReReco-Run2018D-SingleMuon-UL2018_MiniAODv1_NanoAODv2-00002
+  sample_type: data
+  status: VALID
+  version: 2
+ElEmbedding_Run2018A:
+  campaign: ""
+  datasetname: ElEmbedding_Run2018A-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 150
+  nevents: 14960365
+ElEmbedding_Run2018B:
+  campaign: ""
+  datasetname: ElEmbedding_Run2018B-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 72
+  nevents: 7110291
+ElEmbedding_Run2018C:
+  campaign: ""
+  datasetname: ElEmbedding_Run2018C-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 66
+  nevents: 6542941
+ElEmbedding_Run2018D:
+  campaign: ""
+  datasetname: ElEmbedding_Run2018D-UL2018
+  datatier: NANOAOD
+  dbs:
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  sample_type: emb
+  status: VALID
+  version: 1
+  nfiles: 307
+  nevents: 30640012
+EGamma_Run2018A:
+  campaign: ""
+  datasetname: EGamma_Run2018A-UL2018_MiniAODv2_NanoAODv9-v1
+  datatier: NANOAOD
+  dbs: /EGamma/Run2018A-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 339013231
+  nfiles: 226
+  prepid:
+  sample_type: data
+  status: VALID
+  version: 1
+EGamma_Run2018B:
+  campaign: ""
+  datasetname: EGamma_Run2018B-UL2018_MiniAODv2_NanoAODv9-v1
+  datatier: NANOAOD
+  dbs: /EGamma/Run2018B-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 153792795
+  nfiles: 74
+  prepid:
+  sample_type: data
+  status: VALID
+  version: 1
+EGamma_Run2018C:
+  campaign: ""
+  datasetname: EGamma_Run2018C-UL2018_MiniAODv2_NanoAODv9-v1
+  datatier: NANOAOD
+  dbs: /EGamma/Run2018C-UL2018_MiniAODv2_NanoAODv9-v1/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 147827904
+  nfiles: 83
+  prepid:
+  sample_type: data
+  status: VALID
+  version: 1
+EGamma_Run2018D:
+  campaign: ""
+  datasetname: EGamma_Run2018D-UL2018_MiniAODv2_NanoAODv9-v3
+  datatier: NANOAOD
+  dbs: /EGamma/Run2018D-UL2018_MiniAODv2_NanoAODv9-v3/NANOAOD
+  energy: 13
+  era: 2018
+  extension: ""
+  generators: ""
+  nevents: 147827904
+  nfiles: 83
+  prepid:
+  sample_type: data
+  status: VALID
+  version: 3

--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,7 @@ action() {
     fi
     
     #Determine which environment to use based on the luigi.cfg file
-    export ENV_NAME=$(grep "ENV_NAME" lawluigi_configs/${ANA_NAME}_luigi.cfg | sed 's@ENV_NAME\s*=\s*\([^\s]*\)\s*@\1@g')
+    export ENV_NAME=$(grep '^ENV_NAME' lawluigi_configs/${ANA_NAME}_luigi.cfg | sed 's@ENV_NAME\s*=\s*\([^\s]*\)\s*@\1@g')
     echo "Using ${ENV_NAME} environment."
 
     #Check if necessary environment is present in cvmfs
@@ -109,6 +109,8 @@ action() {
         fi
         # create conda tarball if env not in cvmfs and it if it doesn't exist already
         if [ ! -f "tarballs/${ENV_NAME}_env.tar.gz" ]; then
+            # IMPORTANT: environments have to be named differently with each change
+            #            as chaching prevents a clean overwrite of existing files
             echo "Creating ${ENV_NAME}_env.tar.gz"
             mkdir -p "tarballs"
             conda pack -n ${ENV_NAME} --output tarballs/${ENV_NAME}_env.tar.gz


### PR DESCRIPTION
Things that do not work currently:

Using more than one worker with `--workers` will result in the script running indefinetly. This is caused by `output.copy_from_local` running into a gfal timeout (e.g. here https://github.com/KIT-CMS/KingMaker/blob/5c40d1c8c7dcb65e4a62fe096138890b86c3d007/processor/tasks/CROWNBuild.py#L142)

Using only one worker, this works without a hassle. Note the task itself `CROWNBuild` is only run once by a single worker.

--> Fixed now 

Additional Changes:

- [x] move to offical law repo instead of fork
- [x] Added additional folder in CROWNBuild Tarball structure (the `production_tag`
- [x] status line changes
