### PR TITLE
Stream root files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ logs/
 *.txt
 miniconda/
 output/
+CROWN/
 .nfs*
 
 #luigid pickle

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "sm-htt-analysis"]
 	path = sm-htt-analysis
 	url = git@github.com:tvoigtlaender/sm-htt-analysis.git
-[submodule "CROWN"]
-	path = CROWN
-	url = git@github.com:KIT-CMS/CROWN.git

--- a/lawluigi_configs/ML_train_luigi.cfg
+++ b/lawluigi_configs/ML_train_luigi.cfg
@@ -53,10 +53,9 @@ batch_nums = ["2"]
 htcondor_request_cpus = 1
 htcondor_walltime = 3600
 htcondor_request_memory = 2000
-htcondor_requirements = (TARGET.ProvidesEKPResources==True)
 htcondor_request_disk = 2000000
 additional_files = ["sm-htt-analysis/ml_datasets/create_training_datashard.py"]
-tasks_per_job = 20
+tasks_per_job = 12
 [CreateTrainingConfig]
 [CreateTrainingConfigAllEras]
 [RunTraining]

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -222,6 +222,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         description="Accounting group to be set in Hthe TCondor job submission."
     )
     htcondor_requirements = luigi.Parameter(
+        default = "",
         description="Job requirements to be set in the HTCondor job submission."
     )
     htcondor_remote_job = luigi.Parameter(
@@ -301,7 +302,8 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         # config.custom_content.append(("Output", "out_{}to{}.txt".format(branches[0], branches[-1]))) #Remove before commit
         # config.custom_content.append(("stream_error", "True")) #
         # config.custom_content.append(("Output", "err_{}to{}.txt".format(branches[0], branches[-1]))) #
-        config.custom_content.append(("Requirements", self.htcondor_requirements))
+        if self.htcondor_requirements:
+            config.custom_content.append(("Requirements", self.htcondor_requirements))
         config.custom_content.append(("+RemoteJob", self.htcondor_remote_job))
         config.custom_content.append(("universe", self.htcondor_universe))
         config.custom_content.append(("docker_image", self.htcondor_docker_image))

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -222,7 +222,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         description="Accounting group to be set in Hthe TCondor job submission."
     )
     htcondor_requirements = luigi.Parameter(
-        default = "",
+        default="",
         description="Job requirements to be set in the HTCondor job submission."
     )
     htcondor_remote_job = luigi.Parameter(

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -223,7 +223,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
     )
     htcondor_requirements = luigi.Parameter(
         default="",
-        description="Job requirements to be set in the HTCondor job submission."
+        description="Job requirements to be set in the HTCondor job submission.",
     )
     htcondor_remote_job = luigi.Parameter(
         description="Whether RemoteJob should be set in the HTCondor job submission."

--- a/processor/tasks/CreateTrainingDatasets.py
+++ b/processor/tasks/CreateTrainingDatasets.py
@@ -445,7 +445,7 @@ class CreateTrainingConfig(Task, law.LocalWorkflow):
         ]
 
         # Copy filtered shard and shard config files into data directory
-        for copy_file in shardconfigs: # + shards:
+        for copy_file in shardconfigs:
             copy_file_name = os.path.basename(copy_file.path)
             copy_file_name_path = os.path.basename(os.path.dirname(copy_file.path))
             copy_file.copy_to_local(

--- a/processor/tasks/RunTraining.py
+++ b/processor/tasks/RunTraining.py
@@ -256,7 +256,7 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
         remote_shard_base = self.wlcg_path + os.path.dirname(
             os.path.dirname(allbranch_shards[0].path)
         )
-        
+
         # Copy config to local
         trainingconfig_name = os.path.basename(trainingconfig.path)
         trainingconfig.copy_to_local("/".join([local_dir, trainingconfig_name]))

--- a/processor/tasks/RunTraining.py
+++ b/processor/tasks/RunTraining.py
@@ -194,7 +194,7 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
         prefix = self.temporary_local_path("")
         run_loc = "sm-htt-analysis"
         # Create data directory for each branch
-        data_dir = "/".join(
+        local_dir = "/".join(
             [
                 prefix,
                 self.dir_template.format(
@@ -205,7 +205,7 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
                 ),
             ]
         )
-        os.makedirs("/".join([data_dir, self.era]), exist_ok=True)
+        os.makedirs("/".join([local_dir, self.era]), exist_ok=True)
         if self.era == "all_eras":
             use_eras = self.all_eras
         else:
@@ -213,7 +213,7 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
         files = [
             "/".join(
                 [
-                    data_dir,
+                    local_dir,
                     self.era,
                     file_template.format(fold=self.branch_data["fold"]),
                 ]
@@ -226,6 +226,7 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
                 "collection"
             ]
         )
+
         # Filter training config targets by name in each branch
         filefilter_training_config_string = "/".join(
             [
@@ -245,54 +246,24 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
             for target in allbranch_trainingconfigs
             if filefilter_training_config.match(target.path)
         ][0]
-        # Get list of all shard targets
+
+        # Get prefix of remote storage for root shards
         allbranch_shards = flatten_collections(
             self.input()[
                 "CreateTrainingDataShard_{}".format(self.branch_data["channel"])
             ]["collection"]
         )
-        # Filter shard targets by name in each branch and for each process
-        processes, process_classes = zip(
-            *self.get_process_tuple(
-                self.branch_data["channel"],
-                self.branch_data["mass"],
-                self.branch_data["batch_num"],
-            )
+        remote_shard_base = self.wlcg_path + os.path.dirname(
+            os.path.dirname(allbranch_shards[0].path)
         )
-        shards_eras = {}
-        for era in use_eras:
-            filefilter_shard_strings = [
-                "/".join(
-                    [
-                        ".*",
-                        self.dir_template_in.format(
-                            era=era, channel=self.branch_data["channel"]
-                        ),
-                        self.file_template_shard.format(process=process, fold=fold),
-                    ]
-                )
-                for process in processes
-            ]
-            filefilters_shard = [
-                re.compile(string) for string in filefilter_shard_strings
-            ]
-            shards = [
-                [target for target in allbranch_shards if filefilter.match(target.path)]
-                for filefilter in filefilters_shard
-            ]
-            shards_eras[era] = shards
-        # Copy filtered shard and training config files into data directory for each era
-        for era in use_eras:
-            shards = [shard for shards in shards_eras[era] for shard in shards]
-            for shard in shards:
-                shard_name = os.path.basename(shard.path)
-                shard.copy_to_local("/".join([data_dir, era, shard_name]))
+        
+        # Copy config to local
         trainingconfig_name = os.path.basename(trainingconfig.path)
-        trainingconfig.copy_to_local("/".join([data_dir, trainingconfig_name]))
+        trainingconfig.copy_to_local("/".join([local_dir, trainingconfig_name]))
 
         # self.run_command(
         #     command=["ls", "-R"],
-        #     run_location=data_dir
+        #     run_location=local_dir
         # )
         # Set maximum number of threads (this number is somewhat inaccurate
         # as TensorFlow only abides by it for some aspects of the training)
@@ -306,8 +277,10 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
             command=[
                 "python",
                 "ml_trainings/keras_training.py",
-                "--data-dir {}".format(data_dir),
-                "--era {}".format(self.era),
+                "--data-dir {}".format(remote_shard_base),
+                "--config-dir {}".format(local_dir),
+                "--era-training {}".format(self.era),
+                "--channel-training {}".format(self.branch_data["channel"]),
                 "--fold {}".format(fold),
                 "--balance-batches 1",
                 "--max-threads {}".format(max_threads),

--- a/setup.sh
+++ b/setup.sh
@@ -149,8 +149,9 @@ action() {
     case ${ANA_NAME} in
         KingMaker)
             echo "Setting up CROWN ..."
-            if [ -z "$(ls -A CROWN)" ]; then
-                git submodule update --init --recursive -- CROWN
+            # Due to frequent updates CROWN is not set up as a submodule
+            if [ ! -d CROWN ]; then
+                git clone --recursive git@github.com:KIT-CMS/CROWN
             fi
             if [ -z "$(ls -A sample_database)" ]; then
                 git submodule update --init --recursive -- sample_database


### PR DESCRIPTION
Instead of reading root files from /ceph, they are now streamed from dCache.
Also stream root files from remote storage instead of copying them into a job.
Add option for empty Target requirements. 
Run Datashard creation task commands with "ROOT_XRD_QUERY_READV_PARAMS=0" to prevent dCache specific issue with streaming of root files.