### PR TITLE
Change directory of locally stored job files. 

### DIFF
--- a/processor/framework.py
+++ b/processor/framework.py
@@ -418,9 +418,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
                 console.rule("Successful tar of framework tarball !")
             # Copy new tarball to remote
             tarball.parent.touch()
-            tarball.copy_from_local(
-                src=tarball_local.path
-            )
+            tarball.copy_from_local(src=tarball_local.path)
             console.rule("Framework tarball uploaded!")
             os.chdir(prevdir)
         # Check if env of this task was found in cvmfs

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -395,7 +395,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
                 "--exclude",
                 "*.git",
                 "-czf",
-                "{}/{}/processor.tar.gz".format(tarball_dir, task_name),
+                tarball_local.path,
                 "processor",
                 "lawluigi_configs/{}_luigi.cfg".format(analysis_name),
                 "lawluigi_configs/{}_law.cfg".format(analysis_name),
@@ -412,14 +412,14 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
                 console.log("Output: {}".format(out))
                 console.log("tar returned non-zero exit status {}".format(code))
                 console.rule()
-                os.remove("/{}/processor.tar.gz".format(tarball_dir, task_name))
+                os.remove(tarball_local.path)
                 raise Exception("tar failed")
             else:
                 console.rule("Successful tar of framework tarball !")
             # Copy new tarball to remote
             tarball.parent.touch()
             tarball.copy_from_local(
-                src="{}/{}/processor.tar.gz".format(tarball_dir, task_name)
+                src=tarball_local.path
             )
             console.rule("Framework tarball uploaded!")
             os.chdir(prevdir)
@@ -436,7 +436,9 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
             if not tarball_env.exists():
                 tarball_env.parent.touch()
                 tarball_env.copy_from_local(
-                    src="tarballs/conda_envs/{}.tar.gz".format(self.ENV_NAME)
+                    src=os.path.abspath(
+                        "tarballs/conda_envs/{}.tar.gz".format(self.ENV_NAME)
+                    )
                 )
         config.render_variables["USER"] = self.local_user
         config.render_variables["ANA_NAME"] = os.getenv("ANA_NAME")

--- a/scripts/ParseNeededEnv.py
+++ b/scripts/ParseNeededEnv.py
@@ -1,0 +1,26 @@
+import configparser
+from sys import argv
+import os
+
+#print(sys.argv)
+
+cfg_path = argv[1]
+if not os.path.isfile(cfg_path):
+    print('File was not found at {}'.format(cfg_path))
+    exit(1)
+config = configparser.ConfigParser()
+
+try:
+    config.read(cfg_path)
+    base_env = config["DEFAULT"]["ENV_NAME"]
+except (KeyError, configparser.ParsingError) as error:
+    print('File at {} is not a valid config file.@{}'.format(cfg_path, error))
+    exit(1)
+
+all_env = [base_env]
+for section in config.sections():
+    all_env.append(config[section]["ENV_NAME"])
+all_env = list(set(all_env))
+print(base_env)
+for i in all_env:
+    print(i)

--- a/scripts/ParseNeededEnv.py
+++ b/scripts/ParseNeededEnv.py
@@ -2,11 +2,11 @@ import configparser
 from sys import argv
 import os
 
-#print(sys.argv)
+# print(sys.argv)
 
 cfg_path = argv[1]
 if not os.path.isfile(cfg_path):
-    print('File was not found at {}'.format(cfg_path))
+    print("File was not found at {}".format(cfg_path))
     exit(1)
 config = configparser.ConfigParser()
 
@@ -14,7 +14,7 @@ try:
     config.read(cfg_path)
     base_env = config["DEFAULT"]["ENV_NAME"]
 except (KeyError, configparser.ParsingError) as error:
-    print('File at {} is not a valid config file.@{}'.format(cfg_path, error))
+    print("File at {} is not a valid config file.@{}".format(cfg_path, error))
     exit(1)
 
 all_env = [base_env]


### PR DESCRIPTION
This includes all rendered files, the job.jdl files and all log files. The exact file path can still be discussed. 
This collects all files of a remote task at a single location, reducing the endless search in randomly named dirs.

Works by giving the `htcondor_create_job_file_factory` function a custom `dir` and the `mkdtemp=False` parameter.
`log`, `stdout` and `stderr` are standalone parameters of the `config` and do not have to be added as `custom_content`.

Also deactivates the streaming of the job `stdout`/`stderr` as a default, as it can create a lot of communication when many jobs are running.