### PR TITLE
Adapt custom HTCondor workdirs for all workflows

### DIFF
--- a/processor/framework.py
+++ b/processor/framework.py
@@ -320,9 +320,9 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         )
         for file_ in ["Log", "Output", "Error"]:
             os.makedirs(os.path.join(logdir, file_), exist_ok=True)
-        logfile = os.path.join(logdir, "Log", task_name)
-        outfile = os.path.join(logdir,"Output",task_name)
-        errfile = os.path.join(logdir,"Error",task_name)
+        logfile = os.path.join(logdir, "Log", task_name + ".txt")
+        outfile = os.path.join(logdir, "Output", task_name + ".txt")
+        errfile = os.path.join(logdir, "Error", task_name + ".txt")
 
         # Write job config file
         config.custom_content = []

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -48,10 +48,6 @@ class Task(law.Task):
         default="default/{}".format(startup_time),
         description="Tag to differentiate workflow runs. Set to a timestamp as default.",
     )
-    task_identifier = luigi.ListParameter(
-        default=[],
-        description="List of values to distinguish a specific Task from other instances of the same Task. Only takes strings.",
-    )
     output_collection_cls = law.NestedSiblingFileCollection
 
     # Path of local targets. Composed from the analysis path set during the setup.sh,
@@ -297,7 +293,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         # Add identification-str to prevent interference between different tasks of the same class
         # Expand path to account for use of env variables (like $USER)
         return law.wlcg.WLCGDirectoryTarget(
-            self.remote_path("htcondor_files", "_".join(self.task_identifier)),
+            self.remote_path("htcondor_files"),
             law.wlcg.WLCGFileSystem(
                 None, base="{}".format(os.path.expandvars(self.wlcg_path))
             ),
@@ -324,31 +320,21 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         )
         for file_ in ["Log", "Output", "Error"]:
             os.makedirs(os.path.join(logdir, file_), exist_ok=True)
-        logfile = os.path.join(
-            logdir, "Log", "{}_{}to{}.txt".format(task_name, branches[0], branches[-1])
-        )
-        outfile = os.path.join(
-            logdir,
-            "Output",
-            "{}_{}to{}.txt".format(task_name, branches[0], branches[-1]),
-        )
-        errfile = os.path.join(
-            logdir,
-            "Error",
-            "{}_{}to{}.txt".format(task_name, branches[0], branches[-1]),
-        )
+        logfile = os.path.join(logdir, "Log", task_name)
+        outfile = os.path.join(logdir,"Output",task_name)
+        errfile = os.path.join(logdir,"Error",task_name)
 
         # Write job config file
         config.custom_content = []
         config.custom_content.append(
             ("accounting_group", self.htcondor_accounting_group)
         )
-        config.custom_content.append(("Log", logfile))
-        config.custom_content.append(("Output", outfile))
-        config.custom_content.append(("Error", errfile))
+        config.log = os.path.join(logfile)
+        config.stdout = os.path.join(outfile)
+        config.stderr = os.path.join(errfile)
 
-        config.custom_content.append(("stream_error", "True"))  # Remove before commit
-        config.custom_content.append(("stream_output", "True"))  #
+        # config.custom_content.append(("stream_error", "True"))  # Remove before commit
+        # config.custom_content.append(("stream_output", "True"))  #
         if self.htcondor_requirements:
             config.custom_content.append(("Requirements", self.htcondor_requirements))
         config.custom_content.append(("+RemoteJob", self.htcondor_remote_job))
@@ -460,71 +446,3 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
                 "MODULE_PYTHONPATH"
             )
         return config
-
-
-# Class to shorten lookup times for large amounts of output targets
-#    puppet_task: Task to be run
-#    task_identifier: parameters by which the Class instance can be differentiated
-#       from other PuppetMaster tasks that supervise Tasks with the same name
-# Output targets of puppet are saved to the checkfile after puppet is run
-# If output targets of puppet don't match with saved targets, checkfile is removed
-class PuppetMaster(Task):
-    puppet_task = luigi.TaskParameter(description="Task to be supervised.")
-    fulltask = luigi.BoolParameter(
-        default=False, description="Whether the full puppet task should be displayed."
-    )
-
-    # Requirements are the same as puppet task
-    def requires(self):
-        return self.puppet_task.requires()
-
-    def output(self):
-        puppet = self.puppet_task
-        # Construct output filename from class name of puppet and identifier
-        class_name = puppet.__class__.__name__
-        unique_par_str = "_".join([class_name] + list(self.task_identifier))
-        filename = unique_par_str + ".json"
-        target = self.local_target(filename)
-        # Check if existing file matches with new file
-        if target.exists():
-            out = puppet.output()
-            if isinstance(out, DotDict) and "collection" in out.keys():
-                out = out["collection"]
-            target_paths = set([targ.path for targ in flatten_collections(out)])
-            target_paths_from_file = set(target.load())
-            if target_paths != target_paths_from_file:
-                # Remove old file if not
-                console.log("Missmatch in output files found. Removing checkfile.")
-                console.log(
-                    list(target_paths_from_file - target_paths)
-                    + list(target_paths - target_paths_from_file)
-                )
-                target.remove()
-                if target.exists():
-                    raise Exception("File {} could not be deleted".format(target.path))
-        return target
-
-    def repr(self, all_params=False, color=None, **kwargs):
-        representation = super(PuppetMaster, self).repr(all_params, color, **kwargs)
-        if self.fulltask:
-            representation += " of " + self.puppet_task.repr(
-                all_params, color, **kwargs
-            )
-        return representation
-
-    def run(self):
-        puppet = self.puppet_task
-        # Add puppet to shedduler
-        # PuppetMaster Tasks restarts after yield
-        print("Add task to shedduler: ", puppet)
-        yield puppet
-        # Write output targets of puppet to PuppetMaster output target
-        out = puppet.output()
-        if isinstance(out, DotDict) and "collection" in out.keys():
-            out = out["collection"]
-        target_paths = [targ.path for targ in flatten_collections(out)]
-        self.output().dump(target_paths, formatter="json")
-
-    # Get outputs of puppet (Used in non-workflow)
-    def give_puppet_outputs(self):
-        return self.puppet_task.output()

--- a/processor/tasks/CROWNBase.py
+++ b/processor/tasks/CROWNBase.py
@@ -220,19 +220,14 @@ class CROWNExecuteBase(HTCondorWorkflow, law.LocalWorkflow):
             )
         config = super().htcondor_job_config(config, job_num, branches)
         config.custom_content.append(("JobBatchName", condor_batch_name_pattern))
-        for type in ["Log", "Output", "Error"]:
-            logfilepath = ""
-            for param in config.custom_content:
-                if param[0] == type:
-                    logfilepath = param[1]
-                    break
+        for type in ["log", "stdout", "stderr"]:
+            logfilepath = getattr(config, type)
             # split the filename, and add the sample nick as an additional folder
-            logfolder = logfilepath.split("/")[:-1]
-            logfile = logfilepath.split("/")[-1]
-            logfolder.append(self.nick)
+            logfolder, logfile = os.path.split(logfilepath)
+            logfolder = os.path.join(logfolder, self.nick)
             # create the new path
-            os.makedirs("/".join(logfolder), exist_ok=True)
-            config.custom_content.append((type, "/".join(logfolder) + "/" + logfile))
+            os.makedirs(logfolder, exist_ok=True)
+            setattr(config, type, os.path.join(logfolder, logfile))
         return config
 
     def modify_polling_status_line(self, status_line):

--- a/processor/tasks/MLTraining.py
+++ b/processor/tasks/MLTraining.py
@@ -20,6 +20,7 @@ except OSError:
     current_width = 140
 console = Console(width=current_width)
 
+
 # Base task of ML train tasks
 class MLBase(HTCondorWorkflow, law.LocalWorkflow):
     # Redirect location of job files to <job_file_dir>/<production_tag>/<class_name>/"files"/...

--- a/processor/tasks/MLTraining.py
+++ b/processor/tasks/MLTraining.py
@@ -40,6 +40,7 @@ class MLBase(HTCondorWorkflow, law.LocalWorkflow):
         )
         return factory
 
+
 # Task to create root shards for the NN training
 # One shard is created for each process (like "ff" and "NMSSM_240_125_60")
 # Shards are NOT shared between eras and decay channels

--- a/processor/tasks/MLTraining.py
+++ b/processor/tasks/MLTraining.py
@@ -8,10 +8,10 @@ import yaml
 import os
 import luigi
 import law
-from rich.console import Console
-from framework import Task, HTCondorWorkflow, startup_dir
+from framework import HTCondorWorkflow, Console, startup_dir
 from law.target.collection import flatten_collections
 from law.task.base import WrapperTask
+from law.config import Config
 from ml_util.config_merger import get_merged_config
 
 try:
@@ -20,11 +20,30 @@ except OSError:
     current_width = 140
 console = Console(width=current_width)
 
+# Base task of ML train tasks
+class MLBase(HTCondorWorkflow, law.LocalWorkflow):
+    # Redirect location of job files to <job_file_dir>/<production_tag>/<class_name>/"files"/...
+    def htcondor_create_job_file_factory(self):
+        task_name = self.__class__.__name__
+        _cfg = Config.instance()
+        job_file_dir = _cfg.get_expanded("job", "job_file_dir")
+        jobdir = os.path.join(
+            job_file_dir,
+            self.production_tag,
+            task_name,
+            "files",
+        )
+        os.makedirs(jobdir, exist_ok=True)
+        factory = super(HTCondorWorkflow, self).htcondor_create_job_file_factory(
+            dir=jobdir,
+            mkdtemp=False,
+        )
+        return factory
 
 # Task to create root shards for the NN training
 # One shard is created for each process (like "ff" and "NMSSM_240_125_60")
 # Shards are NOT shared between eras and decay channels
-class CreateTrainingDataShard(HTCondorWorkflow, law.LocalWorkflow):
+class CreateTrainingDataShard(MLBase):
     # Define luigi parameters
     datashard_information = luigi.ListParameter(
         description="List of, tuples of process identifier and class mapping"
@@ -135,7 +154,7 @@ class CreateTrainingDataShard(HTCondorWorkflow, law.LocalWorkflow):
 
 
 # Task to run NN training (2 folds)
-class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
+class RunTraining(MLBase):
     # Define luigi parameters
     training_information = luigi.ListParameter(
         description="List of, tuples of training name and training config file"
@@ -394,7 +413,7 @@ class RunTraining(HTCondorWorkflow, law.LocalWorkflow):
 
 
 # Task test the trained NNs (both folds)
-class RunTesting(HTCondorWorkflow, law.LocalWorkflow):
+class RunTesting(MLBase):
     # Define luigi parameters
     training_information = luigi.ListParameter(
         description="List of, tuples of training name and training config file"
@@ -547,19 +566,6 @@ class RunTesting(HTCondorWorkflow, law.LocalWorkflow):
         filtered_data_inputs = [
             input_ for input_ in data_inputs if ".root" in input_.path
         ]
-        # input_dir_list = list(
-        #     set([os.path.dirname(target.path) for target in filtered_data_inputs])
-        # )
-        # if len(input_dir_list) != 1:
-        #     if len(input_dir_list) == 0:
-        #         print(
-        #             "Base directory of datashards could not be found from the task inputs."
-        #         )
-        #     if len(input_dir_list) > 1:
-        #         print("Base directories of the datashards are not the same.")
-        #     raise Exception("Data directory colud not be determined.")
-        # else:
-        #     data_dir = self.wlcg_path + input_dir_list[0]
 
         model_inputs = flatten_collections(self.input()["RunTraining"])
         required_files = [

--- a/processor/tasks/MinimalRemoteExample.py
+++ b/processor/tasks/MinimalRemoteExample.py
@@ -11,12 +11,32 @@
 
 
 import os
-import luigi
 import law
 from framework import Task, HTCondorWorkflow
+from law.config import Config
 
 law.contrib.load("tasks")  # to have the RunOnceTask
 
+
+# Inheriting from this class puts htcondor files into custom directory
+class CuHTask(HTCondorWorkflow, law.LocalWorkflow):
+    # Redirect location of job files to <job_file_dir>/<production_tag>/<class_name>/"files"/...
+    def htcondor_create_job_file_factory(self):
+        task_name = self.__class__.__name__
+        _cfg = Config.instance()
+        job_file_dir = _cfg.get_expanded("job", "job_file_dir")
+        jobdir = os.path.join(
+            job_file_dir,
+            self.production_tag,
+            task_name,
+            "files",
+        )
+        os.makedirs(jobdir, exist_ok=True)
+        factory = super(HTCondorWorkflow, self).htcondor_create_job_file_factory(
+            dir=jobdir,
+            mkdtemp=False,
+        )
+        return factory
 
 class SaveToRemote(Task):
     # Output target is remote and accessed using gfal2.
@@ -30,7 +50,7 @@ class SaveToRemote(Task):
         self.output().dump(saveText)
 
 
-class RunRemote(HTCondorWorkflow, law.LocalWorkflow):
+class RunRemote(CuHTask):
     def requires(self):
         return SaveToRemote.req(self)
 

--- a/processor/tasks/MinimalRemoteExample.py
+++ b/processor/tasks/MinimalRemoteExample.py
@@ -38,6 +38,7 @@ class CuHTask(HTCondorWorkflow, law.LocalWorkflow):
         )
         return factory
 
+
 class SaveToRemote(Task):
     # Output target is remote and accessed using gfal2.
     def output(self):


### PR DESCRIPTION
Add custom job dirs to ML_train and GPU_example workflows. 
Switch to intended config attributes to set log directories. 
Switch off streaming of output logs by default, as traffic can be unpredictable with larger number of simultaneous branches/jobs.
Remove unused parameter `task_identifier` and unused Task `PuppetMaster`.