### PR TITLE
fix unwanted rerun of friend dependencies when running ProduceMultiFriends

### DIFF
--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -74,7 +74,9 @@ class CROWNMultiFriends(CROWNExecuteBase):
             if inputfile.path.endswith(".root")
         ]
         friend_inputs = [
-            self.input()[f"CROWNFriends_{self.nick}_{friend}"]["collection"]
+            self.input()[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"][
+                "collection"
+            ]
             for friend in self.friend_dependencies  # type: ignore
         ]
         friend_branches = [

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -65,7 +65,9 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
             scopes=self.scopes,
         )
         for friend in self.friend_dependencies:
-            requirements[f"CROWNFriends_{friend}"] = CROWNFriends(
+            requirements[
+                f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
+            ] = CROWNFriends(
                 nick=self.nick,
                 analysis=self.analysis,
                 config=self.config,
@@ -75,7 +77,7 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
                 era=self.era,
                 sample_type=self.sample_type,
                 scopes=self.scopes,
-                friend_name=friend,
+                friend_name=self.friend_mapping[friend],
                 friend_config=friend,
             )
         return requirements
@@ -117,7 +119,9 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
                 # add all friend files to the inputfiles list
                 for friend in self.friend_dependencies:
                     inputfiles.extend(
-                        self.input()[f"CROWNFriends_{friend}"][sample]._flat_target_list
+                        self.input()[
+                            f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
+                        ][sample]._flat_target_list
                     )
                 for inputfile in inputfiles:
                     if inputfile.path.endswith("quantities_map.json"):

--- a/processor/tasks/ProduceFriends.py
+++ b/processor/tasks/ProduceFriends.py
@@ -25,7 +25,7 @@ class ProduceFriends(ProduceBase):
             console.log(f"Config: {self.config}")
             console.log(f"Shifts: {self.shifts}")
             console.log(f"Scopes: {self.scopes}")
-            console.log(f"Slient: {self.silent}")
+            console.log(f"Silent: {self.silent}")
             console.rule("")
 
         data = self.set_sample_data(self.parse_samplelist(self.sample_list))


### PR DESCRIPTION
Due to some misconfiguration in the tasks already produces friends were rerun with the config name as friend name instead of taking the produces friends. 