### PR TITLE
Fix parameter for choice of output location

### DIFF
--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -15,7 +15,7 @@ ENV_NAME = KingMaker
 ; storing the output locally (local) or on grid (wlcg)
 ; when using local, make sure to ajust the htcondor requirements so all local paths are accessible
 ; for ETP, that is TARGET.ProvidesEtpResources
-is_local_output = False
+is_local_output = True
 
 ; if the local path is set, the output will be copied to the local path after the job is finished
 local_output_path = /ceph/${USER}/CROWN/ntuples/
@@ -68,7 +68,7 @@ install_dir = tarballs
 ; HTCondor
 htcondor_walltime = 10800
 htcondor_request_memory = 16000
-htcondor_requirements = TARGET.ProvidesEtpResources && TARGET.ProvidesCPU && TARGET.ProvidesIO
+htcondor_requirements = TARGET.ProvidesCPU && TARGET.ProvidesIO
 htcondor_request_disk = 20000000
 # for these eras, only one file per task is processed
 problematic_eras = ["2018B", "2017C", "2016B-ver2"]
@@ -77,7 +77,7 @@ problematic_eras = ["2018B", "2017C", "2016B-ver2"]
 ; HTCondor
 htcondor_walltime = 10800
 htcondor_request_memory = 16000
-htcondor_requirements = TARGET.ProvidesEtpResources && TARGET.ProvidesCPU && TARGET.ProvidesIO
+htcondor_requirements = TARGET.ProvidesCPU && TARGET.ProvidesIO
 htcondor_request_disk = 20000000
 # friends have to be run in single core mode to ensure a correct order of the tree entries
 htcondor_request_cpus = 1
@@ -86,7 +86,7 @@ htcondor_request_cpus = 1
 ; HTCondor
 htcondor_walltime = 10800
 htcondor_request_memory = 16000
-htcondor_requirements = TARGET.ProvidesEtpResources && TARGET.ProvidesCPU && TARGET.ProvidesIO
+htcondor_requirements = TARGET.ProvidesCPU && TARGET.ProvidesIO
 htcondor_request_disk = 20000000
 # friends have to be run in single core mode to ensure a correct order of the tree entries
 htcondor_request_cpus = 1

--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -15,7 +15,7 @@ ENV_NAME = KingMaker
 ; storing the output locally (local) or on grid (wlcg)
 ; when using local, make sure to ajust the htcondor requirements so all local paths are accessible
 ; for ETP, that is TARGET.ProvidesEtpResources
-output_destination = grid
+is_local_output = False
 
 ; if the local path is set, the output will be copied to the local path after the job is finished
 local_output_path = /ceph/${USER}/CROWN/ntuples/
@@ -68,7 +68,7 @@ install_dir = tarballs
 ; HTCondor
 htcondor_walltime = 10800
 htcondor_request_memory = 16000
-htcondor_requirements = TARGET.ProvidesCPU && TARGET.ProvidesIO
+htcondor_requirements = TARGET.ProvidesEtpResources && TARGET.ProvidesCPU && TARGET.ProvidesIO
 htcondor_request_disk = 20000000
 # for these eras, only one file per task is processed
 problematic_eras = ["2018B", "2017C", "2016B-ver2"]
@@ -77,7 +77,7 @@ problematic_eras = ["2018B", "2017C", "2016B-ver2"]
 ; HTCondor
 htcondor_walltime = 10800
 htcondor_request_memory = 16000
-htcondor_requirements = TARGET.ProvidesCPU && TARGET.ProvidesIO
+htcondor_requirements = TARGET.ProvidesEtpResources && TARGET.ProvidesCPU && TARGET.ProvidesIO
 htcondor_request_disk = 20000000
 # friends have to be run in single core mode to ensure a correct order of the tree entries
 htcondor_request_cpus = 1
@@ -86,7 +86,7 @@ htcondor_request_cpus = 1
 ; HTCondor
 htcondor_walltime = 10800
 htcondor_request_memory = 16000
-htcondor_requirements = TARGET.ProvidesCPU && TARGET.ProvidesIO
+htcondor_requirements = TARGET.ProvidesEtpResources && TARGET.ProvidesCPU && TARGET.ProvidesIO
 htcondor_request_disk = 20000000
 # friends have to be run in single core mode to ensure a correct order of the tree entries
 htcondor_request_cpus = 1

--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -15,7 +15,7 @@ ENV_NAME = KingMaker
 ; storing the output locally (local) or on grid (wlcg)
 ; when using local, make sure to ajust the htcondor requirements so all local paths are accessible
 ; for ETP, that is TARGET.ProvidesEtpResources
-is_local_output = True
+is_local_output = False
 
 ; if the local path is set, the output will be copied to the local path after the job is finished
 local_output_path = /ceph/${USER}/CROWN/ntuples/

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -53,7 +53,8 @@ class Task(law.Task):
         default=os.getenv("ANALYSIS_DATA_PATH"),
     )
     is_local_output = luigi.BoolParameter(
-        description="Whether to use local storage. False by default."
+        description="Whether to use local storage. False by default.",
+        default=False,
     )
 
     # Behaviour of production_tag:


### PR DESCRIPTION
The parameter `output_destination`, which is referred to in `lawluigi_configs/KingMaker_luigi.cfg`, does not exist in the base task class in `processor/framework.py`. Instead, the boolean parameter `is_local_output` is used to choose the destination of the output files. This pull requests sets the default parameter of this parameter to `False` explicitly. `output_destination = grid` in the config file is replaced with `is_local_output = False`.