### PR TITLE
Fix for FriendQuantitiesMap and ConfigureDatasets

### DIFF
--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -50,6 +50,7 @@ class CROWNRun(CROWNExecuteBase):
             nick=self.nick,
             era=self.era,
             sample_type=self.sample_type,
+            production_tag=self.production_tag,
         )
         # since we use the filelist from the dataset, we need to run it first
         dataset.run()

--- a/processor/tasks/ConfigureDatasets.py
+++ b/processor/tasks/ConfigureDatasets.py
@@ -14,12 +14,13 @@ def ensure_dir(file_path):
 
 class ConfigureDatasets(Task):
     """
-    Gather information on the selected datasets, for now just mentioning an explicit dataset
+    Gather information on the selected datasets.
     """
 
     nick = luigi.Parameter()
     era = luigi.Parameter()
     sample_type = luigi.Parameter()
+    production_tag = luigi.Parameter()
     silent = luigi.BoolParameter(default=False, significant=False)
 
     def output(self):

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -32,7 +32,7 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
 
     def requires(self):
         requirements = {}
-        requirements["ntuples"] = CROWNRun(self)
+        requirements["ntuples"] = CROWNRun.req(self)
         for friend in self.friend_dependencies:
             requirements[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"] = (
                 CROWNFriends.req(


### PR DESCRIPTION
The problem with `ConfigureDatasets` is that somehow if the production_tag parameter is not specifically set, this task is run each time `law run ...` is executed in default mode and produces an unwanted output in `/store/user/{USER}/CROWN/ntuples/default/{2025_03_06_17_53_30_296429}/ConfigureDatasets` with the current time stamp.

For FriendQuantitiesMap the `req()` method was missed in https://github.com/KIT-CMS/KingMaker/pull/56 for one of the requirements.