### PR TITLE
Simplify MultiFriend logic

### DIFF
--- a/processor/tasks/CROWNBase.py
+++ b/processor/tasks/CROWNBase.py
@@ -74,37 +74,13 @@ class ProduceBase(Task, WrapperTask):
             # now convert the list to a comma separated string
             self.shifts = convert_to_comma_seperated(self.shifts)
 
-    def sanitize_friend_dependencies(self):
-        """
-        The function `sanitize_friend_dependencies` checks the type of `self.friend_dependencies` and
-        converts it to a list if it is a string.
-        """
-        # in this case, the required friends require not only the ntuple, but also other friends,
-        # this means we have to add additional requirements to the task
-        if isinstance(self.friend_dependencies, str):
-            self.friend_dependencies = self.friend_dependencies.split(",")
-        elif isinstance(self.friend_dependencies, list):
-            self.friend_dependencies = self.friend_dependencies
-
     def validate_friend_mapping(self):
         """
-        The function `validate_friend_mapping` checks if the `friend_mapping` dictionary is empty, and if
-        so, creates a new dictionary with `friend_dependencies` as keys and values, otherwise it checks if
-        each friend in `friend_dependencies` is present in `friend_mapping` and raises an exception if not.
+        The function validates that the friend_mapping dictionary is not empty.
+        If empty, raises an exception since we need the mapping information.
         """
-        data = {}
         if len(self.friend_mapping.keys()) == 0:
-            for friend in self.friend_dependencies:
-                data[friend] = friend
-        else:
-            for friend in self.friend_dependencies:
-                if friend in self.friend_mapping:
-                    data[friend] = self.friend_mapping[friend]
-                else:
-                    raise Exception(
-                        f"Friend {friend} not found in friend mapping {self.friend_mapping}"
-                    )
-        self.friend_mapping = data
+            raise Exception("Friend mapping cannot be empty")
 
     def set_sample_data(self, samples):
         """

--- a/processor/tasks/CROWNBuildMultiFriend.py
+++ b/processor/tasks/CROWNBuildMultiFriend.py
@@ -18,7 +18,6 @@ class CROWNBuildMultiFriend(CROWNBuildBase):
     era = luigi.Parameter()
     sample_type = luigi.Parameter()
     nick = luigi.Parameter(significant=False)
-    friend_dependencies = luigi.ListParameter(significant=False)
     friend_mapping = luigi.DictParameter(significant=False, default={})
 
     def requires(self):

--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -17,8 +17,6 @@ law.contrib.load("wlcg")
 
 
 class CROWNMultiFriends(CROWNExecuteBase):
-
-    friend_dependencies = luigi.ListParameter(significant=False)
     friend_mapping = luigi.DictParameter(significant=False, default={})
     friend_config = luigi.Parameter()
     config = luigi.Parameter(significant=False)
@@ -30,7 +28,7 @@ class CROWNMultiFriends(CROWNExecuteBase):
         requirements = {}
         requirements["ntuples"] = CROWNRun.req(self)
         requirements["friend_tarball"] = CROWNBuildMultiFriend.req(self)
-        for friend in self.friend_dependencies:
+        for friend in self.friend_mapping:
             requirements[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"] = (
                 CROWNFriends.req(
                     self, friend_name=self.friend_mapping[friend], friend_config=friend
@@ -54,7 +52,7 @@ class CROWNMultiFriends(CROWNExecuteBase):
             self.input()[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"][
                 "collection"
             ]
-            for friend in self.friend_dependencies  # type: ignore
+            for friend in self.friend_mapping  # type: ignore
         ]
         friend_branches = [
             [
@@ -80,7 +78,7 @@ class CROWNMultiFriends(CROWNExecuteBase):
                     "filecounter": int(counter / len(self.scopes)),
                 }
                 filename = inputfile.path.split("/")[-1]
-                for friend_index, friend in enumerate(self.friend_dependencies):
+                for friend_index, friend in enumerate(self.friend_mapping):
                     if not friend_branches[friend_index][counter].path.endswith(
                         ".root"
                     ):

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -16,13 +16,12 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
     analysis = luigi.Parameter(significant=False)
     config = luigi.Parameter(significant=False)
     nick = luigi.Parameter(significant=False)
-    friend_dependencies = luigi.ListParameter(significant=False)
     friend_mapping = luigi.DictParameter(significant=False, default={})
 
     def workflow_requires(self):
         requirements = {}
         requirements["ntuples"] = CROWNRun.req(self)
-        for friend in self.friend_dependencies:
+        for friend in self.friend_mapping:
             requirements[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"] = (
                 CROWNFriends.req(
                     self, friend_name=self.friend_mapping[friend], friend_config=friend
@@ -33,7 +32,7 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
     def requires(self):
         requirements = {}
         requirements["ntuples"] = CROWNRun.req(self)
-        for friend in self.friend_dependencies:
+        for friend in self.friend_mapping:
             requirements[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"] = (
                 CROWNFriends.req(
                     self, friend_name=self.friend_mapping[friend], friend_config=friend
@@ -71,7 +70,7 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
             ):
                 inputfiles = self.input()["ntuples"][sample]._flat_target_list
                 # add all friend files to the inputfiles list
-                for friend in self.friend_dependencies:
+                for friend in self.friend_mapping:
                     inputfiles.extend(
                         self.input()[
                             f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"

--- a/processor/tasks/ProduceMultiFriends.py
+++ b/processor/tasks/ProduceMultiFriends.py
@@ -13,13 +13,11 @@ class ProduceMultiFriends(ProduceBase):
 
     friend_config = luigi.Parameter()
     friend_name = luigi.Parameter()
-    friend_dependencies = luigi.Parameter()
     friend_mapping = luigi.DictParameter(significant=False, default={})
 
     def requires(self):
         self.sanitize_scopes()
         self.sanitize_shifts()
-        self.sanitize_friend_dependencies()
         self.validate_friend_mapping()
         if not self.silent:
             console.rule("")
@@ -29,7 +27,6 @@ class ProduceMultiFriends(ProduceBase):
             console.log(f"Config: {self.config}")
             console.log(f"Shifts: {self.shifts}")
             console.log(f"Scopes: {self.scopes}")
-            console.log(f"Friend Dependencies: {self.friend_dependencies}")
             console.log(f"Friend Mapping: {self.friend_mapping}")
             console.rule("")
 


### PR DESCRIPTION
Remove the argument --friend-dependencies and use keys of --friend-mapping instead.
Related to #62 .

This change will require an update of the CROWN documentation.