### PR TITLE
Moving NanoAOD version Parameter to global Task

### DIFF
--- a/processor/framework.py
+++ b/processor/framework.py
@@ -1,10 +1,10 @@
 import os
-import law.task
 import luigi
 import law
 import select
 import subprocess
 import socket
+from enum import Enum
 from law.util import interruptable_popen
 from rich.console import Console
 from datetime import datetime
@@ -44,6 +44,12 @@ else:
     startup_dir = os.getcwd()
 
 
+class NanoAODVersions(Enum):
+    v9 = "nanoAOD_v9"
+    v12 = "nanoAOD_v12"
+    v15 = "nanoAOD_v15"
+
+    
 class Task(law.Task):
     local_user = getuser()
     wlcg_path = luigi.Parameter(
@@ -65,6 +71,10 @@ class Task(law.Task):
     production_tag = luigi.Parameter(
         default=f"default/{startup_time}",
         description="Tag to differentiate workflow runs. Set to a timestamp as default.",
+    )
+    nanoAOD_version = luigi.Parameter(
+        default=NanoAODVersions.v12.value,
+        description="Version of the NanoAOD files that are used in the analysis. 'NanoAOD_v12' is the default.",
     )
 
     # Ensure that branch parameter is processed normally

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -49,7 +49,7 @@ class NanoAODVersions(Enum):
     v12 = "nanoAOD_v12"
     v15 = "nanoAOD_v15"
 
-    
+
 class Task(law.Task):
     local_user = getuser()
     wlcg_path = luigi.Parameter(

--- a/processor/tasks/CROWNBase.py
+++ b/processor/tasks/CROWNBase.py
@@ -9,11 +9,7 @@ from law.task.base import WrapperTask
 from rich.table import Table
 from helpers.helpers import convert_to_comma_seperated
 import hashlib
-
-# import timeout_decorator
 import time
-
-from processor.tasks.helpers.NanoAODVersions import NanoAODVersions
 
 
 class ProduceBase(Task, WrapperTask):
@@ -25,7 +21,6 @@ class ProduceBase(Task, WrapperTask):
     sample_list = luigi.Parameter()
     analysis = luigi.Parameter()
     config = luigi.Parameter()
-    nanoAOD_version = luigi.Parameter(default=NanoAODVersions.v12.value)
     dataset_database = luigi.Parameter(default="", significant=False)
     shifts = luigi.Parameter()
     scopes = luigi.Parameter()
@@ -147,7 +142,6 @@ class CROWNExecuteBase(HTCondorWorkflow, law.LocalWorkflow):
     Gather and compile CROWN with the given configuration
     """
 
-    nanoAOD_version = luigi.Parameter(default=NanoAODVersions.v12.value)
     scopes = luigi.ListParameter()
     all_sample_types = luigi.ListParameter(significant=False)
     all_eras = luigi.ListParameter(significant=False)
@@ -271,7 +265,6 @@ class CROWNBuildBase(Task):
 
         return build_dir, install_dir
 
-    # @timeout_decorator.timeout(10)
     def copy_from_local_with_timeout(self, output, path):
         output.copy_from_local(path)
 

--- a/processor/tasks/CROWNFriends.py
+++ b/processor/tasks/CROWNFriends.py
@@ -7,8 +7,6 @@ import tarfile
 import subprocess
 import time
 from framework import console
-from framework import HTCondorWorkflow
-from law.config import Config
 from helpers.helpers import create_abspath
 from CROWNBase import CROWNExecuteBase
 

--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -8,8 +8,6 @@ import tarfile
 import subprocess
 import time
 from framework import console
-from framework import HTCondorWorkflow
-from law.config import Config
 from helpers.helpers import create_abspath
 from CROWNBase import CROWNExecuteBase
 

--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -1,4 +1,3 @@
-import law
 import luigi
 import os
 from CROWNBuild import CROWNBuild
@@ -7,8 +6,6 @@ from ConfigureDatasets import ConfigureDatasets
 import subprocess
 import time
 from framework import console
-from law.config import Config
-from framework import Task, HTCondorWorkflow
 from helpers.helpers import create_abspath
 from CROWNBase import CROWNExecuteBase
 

--- a/processor/tasks/ConfigureDatasets.py
+++ b/processor/tasks/ConfigureDatasets.py
@@ -3,7 +3,6 @@ import os
 import json
 from framework import Task
 from framework import console
-from processor.tasks.helpers.NanoAODVersions import NanoAODVersions
 
 
 def ensure_dir(file_path):
@@ -18,7 +17,6 @@ class ConfigureDatasets(Task):
     """
 
     nick = luigi.Parameter()
-    nanoAOD_version = luigi.Parameter(default=NanoAODVersions.v12.value)
     era = luigi.Parameter()
     sample_type = luigi.Parameter()
     silent = luigi.BoolParameter(default=False, significant=False)
@@ -40,7 +38,7 @@ class ConfigureDatasets(Task):
                     print(exc)
                     raise Exception("Failed to load sample information")
         else:
-            console.log("[DEPRECATED] Loading from DAS is not supported anymore")
+            console.log(f"The sample config json does not exist: {sample_configfile_json}")
             raise Exception("Failed to load sample information")
         return sample_data
 

--- a/processor/tasks/ConfigureDatasets.py
+++ b/processor/tasks/ConfigureDatasets.py
@@ -38,7 +38,9 @@ class ConfigureDatasets(Task):
                     print(exc)
                     raise Exception("Failed to load sample information")
         else:
-            console.log(f"The sample config json does not exist: {sample_configfile_json}")
+            console.log(
+                f"The sample config json does not exist: {sample_configfile_json}"
+            )
             raise Exception("Failed to load sample information")
         return sample_data
 

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -1,7 +1,7 @@
 import luigi
 import law
 import os
-from framework import Task, console
+from framework import Task
 from CROWNRun import CROWNRun
 from CROWNFriends import CROWNFriends
 import json

--- a/processor/tasks/ProduceFriends.py
+++ b/processor/tasks/ProduceFriends.py
@@ -1,6 +1,5 @@
 import luigi
 from CROWNFriends import CROWNFriends
-from CROWNMultiFriends import CROWNMultiFriends
 from framework import console
 from CROWNBase import ProduceBase
 
@@ -25,6 +24,7 @@ class ProduceFriends(ProduceBase):
             console.log(f"Config: {self.config}")
             console.log(f"Shifts: {self.shifts}")
             console.log(f"Scopes: {self.scopes}")
+            console.log(f"NanoAOD: {self.nanoAOD_version}")
             console.log(f"Silent: {self.silent}")
             console.rule("")
 

--- a/processor/tasks/ProduceMultiFriends.py
+++ b/processor/tasks/ProduceMultiFriends.py
@@ -1,5 +1,4 @@
 import luigi
-from CROWNFriends import CROWNFriends
 from CROWNMultiFriends import CROWNMultiFriends
 from framework import console
 from CROWNBase import ProduceBase
@@ -27,6 +26,7 @@ class ProduceMultiFriends(ProduceBase):
             console.log(f"Config: {self.config}")
             console.log(f"Shifts: {self.shifts}")
             console.log(f"Scopes: {self.scopes}")
+            console.log(f"NanoAOD: {self.nanoAOD_version}")
             console.log(f"Friend Mapping: {self.friend_mapping}")
             console.rule("")
 

--- a/processor/tasks/ProduceSamples.py
+++ b/processor/tasks/ProduceSamples.py
@@ -18,6 +18,7 @@ class ProduceSamples(ProduceBase):
             console.log(f"Config: {self.config}")
             console.log(f"Shifts: {self.shifts}")
             console.log(f"Scopes: {self.scopes}")
+            console.log(f"NanoAOD: {self.nanoAOD_version}")
             console.rule("")
 
         data = self.set_sample_data(self.parse_samplelist(self.sample_list))

--- a/processor/tasks/helpers/NanoAODVersions.py
+++ b/processor/tasks/helpers/NanoAODVersions.py
@@ -1,7 +1,0 @@
-from enum import Enum
-
-
-class NanoAODVersions(Enum):
-    v9 = "nanoAOD_v9"
-    v12 = "nanoAOD_v12"
-    v15 = "nanoAOD_v15"


### PR DESCRIPTION
This PR moves the definition of the `nanoAOD_version` parameter to the global `Task`. By doing this it is no longer needed to specify it in any of the more specific tasks since it is always inherited.

Additionally, unused imports are removed from some files.