### PR TITLE
Improve dcache accessing

### DIFF
--- a/processor/tasks/CROWNBuildFriend.py
+++ b/processor/tasks/CROWNBuildFriend.py
@@ -38,12 +38,13 @@ class CROWNBuildFriend(CROWNBuildBase):
         return target
 
     def run(self):
-        crownlib = self.input()["crownlib"]
+        inputs = self.input()
+        crownlib = inputs["crownlib"]
         # get output file path
         output = self.output()
         quantity_target = []
         # get quantities map
-        for target in self.input()["quantities_map"]["collection"]._iter_flat():
+        for target in inputs["quantities_map"]["collection"]._iter_flat():
             quantity_target = target[1]
         if len(quantity_target) != 1:
             raise Exception(

--- a/processor/tasks/CROWNBuildMultiFriend.py
+++ b/processor/tasks/CROWNBuildMultiFriend.py
@@ -33,12 +33,13 @@ class CROWNBuildMultiFriend(CROWNBuildBase):
         return target
 
     def run(self):
-        crownlib = self.input()["crownlib"]
+        inputs = self.input()
+        crownlib = inputs["crownlib"]
         # get output file path
         output = self.output()
         quantity_target = []
         # get quantities map
-        for target in self.input()["quantities_map"]["collection"]._iter_flat():
+        for target in inputs["quantities_map"]["collection"]._iter_flat():
             quantity_target = target[1]
         if len(quantity_target) != 1:
             raise Exception(

--- a/processor/tasks/CROWNFriends.py
+++ b/processor/tasks/CROWNFriends.py
@@ -30,9 +30,6 @@ class CROWNFriends(CROWNExecuteBase):
         requirements["friend_tarball"] = CROWNBuildFriend.req(self)
         return requirements
 
-    def requires(self):
-        return {"friend_tarball": CROWNBuildFriend.req(self)}
-
     def create_branch_map(self):
         """
         The function `create_branch_map` creates a dictionary `branch_map` that maps file counters to
@@ -41,7 +38,7 @@ class CROWNFriends(CROWNExecuteBase):
         """
         branch_map = {}
         counter = 0
-        inputs = self.input()["ntuples"]["collection"]
+        inputs = self.workflow_input()["ntuples"]["collection"]
         branches = inputs._flat_target_list
         # get all files from the dataset, including missing ones
         for inputfile in branches:
@@ -122,10 +119,10 @@ class CROWNFriends(CROWNExecuteBase):
         )
         console.log(
             "Getting CROWN friend_tarball from {}".format(
-                self.input()["friend_tarball"].uri()
+                self.workflow_input()["friend_tarball"].uri()
             )
         )
-        with self.input()["friend_tarball"].localize("r") as _file:
+        with self.workflow_input()["friend_tarball"].localize("r") as _file:
             _tarballpath = _file.path
         # first unpack the tarball if the exec is not there yet
         tempfile = os.path.join(

--- a/processor/tasks/CROWNFriends.py
+++ b/processor/tasks/CROWNFriends.py
@@ -84,8 +84,6 @@ class CROWNFriends(CROWNExecuteBase):
                 )
             )
         targets = self.remote_target(nicks)
-        for target in targets:
-            target.parent.touch()
         return targets
 
     def run(self):
@@ -179,7 +177,6 @@ class CROWNFriends(CROWNExecuteBase):
         else:
             console.log("Successful")
         console.log("Output files afterwards: {}".format(os.listdir(_workdir)))
-        output.parent.touch()
         local_filename = os.path.join(
             _workdir,
             _outputfile.replace(".root", "_{}.root".format(scope)),
@@ -189,7 +186,6 @@ class CROWNFriends(CROWNExecuteBase):
         console.log("Uploaded {}".format(output.uri()))
         if create_quantities_map and quantities_map_output is not None:
             console.log("Creating quantities_map.json")
-            quantities_map_output.parent.touch()
             inputfile = os.path.join(
                 _workdir,
                 _outputfile.replace(".root", "_{}.root".format(scope)),

--- a/processor/tasks/CROWNFriends.py
+++ b/processor/tasks/CROWNFriends.py
@@ -95,6 +95,7 @@ class CROWNFriends(CROWNExecuteBase):
         """
         outputs = self.output()
         output = outputs[0]
+        inputs = self.workflow_input()
         branch_data = self.branch_data
         scope = branch_data["scope"]
         era = branch_data["era"]
@@ -119,10 +120,10 @@ class CROWNFriends(CROWNExecuteBase):
         )
         console.log(
             "Getting CROWN friend_tarball from {}".format(
-                self.workflow_input()["friend_tarball"].uri()
+                inputs["friend_tarball"].uri()
             )
         )
-        with self.workflow_input()["friend_tarball"].localize("r") as _file:
+        with inputs["friend_tarball"].localize("r") as _file:
             _tarballpath = _file.path
         # first unpack the tarball if the exec is not there yet
         tempfile = os.path.join(

--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -46,7 +46,7 @@ class CROWNMultiFriends(CROWNExecuteBase):
         friend_inputs = [
             self.workflow_input()[
                 f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
-                ]["collection"]
+            ]["collection"]
             for friend in self.friend_mapping  # type: ignore
         ]
         friend_branches = [

--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -44,9 +44,9 @@ class CROWNMultiFriends(CROWNExecuteBase):
             if inputfile.path.endswith(".root")
         ]
         friend_inputs = [
-            inputs[
-                f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
-            ]["collection"]
+            inputs[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"][
+                "collection"
+            ]
             for friend in self.friend_mapping  # type: ignore
         ]
         friend_branches = [
@@ -119,8 +119,6 @@ class CROWNMultiFriends(CROWNExecuteBase):
             )
 
         targets = self.remote_target(nicks)
-        for target in targets:
-            target.parent.touch()
         return targets
 
     def run(self):
@@ -217,7 +215,6 @@ class CROWNMultiFriends(CROWNExecuteBase):
         else:
             console.log("Successful")
         console.log("Output files afterwards: {}".format(os.listdir(_workdir)))
-        output.parent.touch()
         local_filename = os.path.join(
             _workdir,
             _outputfile.replace(".root", "_{}.root".format(scope)),
@@ -225,7 +222,6 @@ class CROWNMultiFriends(CROWNExecuteBase):
         # for each outputfile, add the scope suffix
         output.copy_from_local(local_filename)
         if create_quantities_map and quantities_map_output is not None:
-            quantities_map_output.parent.touch()
             inputfile = os.path.join(
                 _workdir,
                 _outputfile.replace(".root", "_{}.root".format(scope)),

--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -37,14 +37,14 @@ class CROWNMultiFriends(CROWNExecuteBase):
     def create_branch_map(self):
         branch_map = {}
         counter = 0
-        inputs = self.workflow_input()["ntuples"]["collection"]
+        inputs = self.workflow_input()
         branches = [
             inputfile
-            for inputfile in inputs._flat_target_list
+            for inputfile in inputs["ntuples"]["collection"]._flat_target_list
             if inputfile.path.endswith(".root")
         ]
         friend_inputs = [
-            self.workflow_input()[
+            inputs[
                 f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
             ]["collection"]
             for friend in self.friend_mapping  # type: ignore
@@ -130,6 +130,7 @@ class CROWNMultiFriends(CROWNExecuteBase):
         """
         outputs = self.output()
         output = outputs[0]
+        inputs = self.workflow_input()
         branch_data = self.branch_data
         scope = branch_data["scope"]
         era = branch_data["era"]
@@ -157,10 +158,10 @@ class CROWNMultiFriends(CROWNExecuteBase):
         )
         console.log(
             "Getting CROWN friend_tarball from {}".format(
-                self.workflow_input()["friend_tarball"].uri()
+                inputs["friend_tarball"].uri()
             )
         )
-        with self.workflow_input()["friend_tarball"].localize("r") as _file:
+        with inputs["friend_tarball"].localize("r") as _file:
             _tarballpath = _file.path
         # first unpack the tarball if the exec is not there yet
         tempfile = os.path.join(

--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -34,20 +34,17 @@ class CROWNMultiFriends(CROWNExecuteBase):
             )
         return requirements
 
-    def requires(self):
-        return {"friend_tarball": CROWNBuildMultiFriend.req(self)}
-
     def create_branch_map(self):
         branch_map = {}
         counter = 0
-        inputs = self.input()["ntuples"]["collection"]
+        inputs = self.workflow_input()["ntuples"]["collection"]
         branches = [
             inputfile
             for inputfile in inputs._flat_target_list
             if inputfile.path.endswith(".root")
         ]
         friend_inputs = [
-            self.input()[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"][
+            self.workflow_input()[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"][
                 "collection"
             ]
             for friend in self.friend_mapping  # type: ignore
@@ -160,10 +157,10 @@ class CROWNMultiFriends(CROWNExecuteBase):
         )
         console.log(
             "Getting CROWN friend_tarball from {}".format(
-                self.input()["friend_tarball"].uri()
+                self.workflow_input()["friend_tarball"].uri()
             )
         )
-        with self.input()["friend_tarball"].localize("r") as _file:
+        with self.workflow_input()["friend_tarball"].localize("r") as _file:
             _tarballpath = _file.path
         # first unpack the tarball if the exec is not there yet
         tempfile = os.path.join(

--- a/processor/tasks/CROWNMultiFriends.py
+++ b/processor/tasks/CROWNMultiFriends.py
@@ -44,9 +44,9 @@ class CROWNMultiFriends(CROWNExecuteBase):
             if inputfile.path.endswith(".root")
         ]
         friend_inputs = [
-            self.workflow_input()[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"][
-                "collection"
-            ]
+            self.workflow_input()[
+                f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
+                ]["collection"]
             for friend in self.friend_mapping  # type: ignore
         ]
         friend_branches = [

--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -95,8 +95,6 @@ class CROWNRun(CROWNExecuteBase):
                 for scope in self.scopes
             ]
         targets = self.remote_target(nicks)
-        for target in targets:
-            target.parent.touch()
         return targets
 
     def run(self):
@@ -192,7 +190,6 @@ class CROWNRun(CROWNExecuteBase):
             console.log("Successful")
         console.log("Output files afterwards: {}".format(os.listdir(_workdir)))
         for i, outputfile in enumerate(rootfile_outputs):
-            outputfile.parent.touch()
             local_filename = os.path.join(
                 _workdir,
                 _outputfile.replace(".root", "_{}.root".format(self.scopes[i])),
@@ -218,7 +215,6 @@ class CROWNRun(CROWNExecuteBase):
         # only do it if the branch number is 0
         if self.branch == 0:
             for i, outputfile in enumerate(quantities_map_outputs):
-                outputfile.parent.touch()
                 inputfile = os.path.join(
                     _workdir,
                     _outputfile.replace(".root", "_{}.root".format(self.scopes[i])),

--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -32,15 +32,6 @@ class CROWNRun(CROWNExecuteBase):
                 )
         return requirements
 
-    def requires(self):
-        requirements = {}
-        for sample_type in self.all_sample_types:
-            for era in self.all_eras:
-                requirements[f"tarball_{sample_type}_{era}"] = CROWNBuild.req(
-                    self, era=era, sample_type=sample_type
-                )
-        return requirements
-
     def create_branch_map(self):
         branch_map = {}
         branchcounter = 0
@@ -133,7 +124,7 @@ class CROWNRun(CROWNExecuteBase):
         _abs_executable = "{}/{}_{}_{}".format(
             _workdir, self.config, branch_data["sample_type"], branch_data["era"]
         )
-        _tarball = self.input()["tarball_{}_{}".format(_sample_type, _era)]
+        _tarball = self.workflow_input()["tarball_{}_{}".format(_sample_type, _era)]
         console.log(f"Getting CROWN tarball from {_tarball.uri()}")
         with _tarball.localize("r") as _file:
             _tarballpath = _file.path

--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -101,6 +101,7 @@ class CROWNRun(CROWNExecuteBase):
 
     def run(self):
         outputs = self.output()
+        inputs = self.workflow_input()
         rootfile_outputs = [x for x in outputs if x.path.endswith(".root")]
         quantities_map_outputs = [
             x for x in outputs if x.path.endswith("quantities_map.json")
@@ -124,7 +125,7 @@ class CROWNRun(CROWNExecuteBase):
         _abs_executable = "{}/{}_{}_{}".format(
             _workdir, self.config, branch_data["sample_type"], branch_data["era"]
         )
-        _tarball = self.workflow_input()["tarball_{}_{}".format(_sample_type, _era)]
+        _tarball = inputs["tarball_{}_{}".format(_sample_type, _era)]
         console.log(f"Getting CROWN tarball from {_tarball.uri()}")
         with _tarball.localize("r") as _file:
             _tarballpath = _file.path

--- a/processor/tasks/ConfigureDatasets.py
+++ b/processor/tasks/ConfigureDatasets.py
@@ -46,9 +46,7 @@ class ConfigureDatasets(Task):
 
     def run(self):
         output = self.output()
-        output.parent.touch()
         if not output.exists():
-            output.parent.touch()
             sample_data = self.load_filelist_config()
             if not self.silent:
                 console.log("Sample: {}".format(self.nick))

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -38,7 +38,6 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
                 self.production_tag, self.era, self.sample_type
             )
         )
-        target.parent.touch()
         return target
 
     def run(self):

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -52,17 +52,17 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
         quantities_map[era] = {}
         quantities_map[era][sample_type] = {}
         # go through all input files and get all quantities maps
-        samples = self.workflow_input()["ntuples"]
-        for sample in samples:
+        inputs = self.workflow_input()
+        for sample in inputs["ntuples"]:
             if isinstance(
-                self.workflow_input()["ntuples"][sample],
+                inputs["ntuples"][sample],
                 law.NestedSiblingFileCollection,
             ):
-                inputfiles = self.workflow_input()["ntuples"][sample]._flat_target_list
+                inputfiles = inputs["ntuples"][sample]._flat_target_list
                 # add all friend files to the inputfiles list
                 for friend in self.friend_mapping:
                     inputfiles.extend(
-                        self.workflow_input()[
+                        inputs[
                             f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
                         ][sample]._flat_target_list
                     )

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -55,7 +55,8 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
         samples = self.workflow_input()["ntuples"]
         for sample in samples:
             if isinstance(
-                self.workflow_input()["ntuples"][sample], law.NestedSiblingFileCollection
+                self.workflow_input()["ntuples"][sample],
+                law.NestedSiblingFileCollection,
             ):
                 inputfiles = self.workflow_input()["ntuples"][sample]._flat_target_list
                 # add all friend files to the inputfiles list

--- a/processor/tasks/FriendQuantitiesMap.py
+++ b/processor/tasks/FriendQuantitiesMap.py
@@ -29,17 +29,6 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
             )
         return requirements
 
-    def requires(self):
-        requirements = {}
-        requirements["ntuples"] = CROWNRun.req(self)
-        for friend in self.friend_mapping:
-            requirements[f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"] = (
-                CROWNFriends.req(
-                    self, friend_name=self.friend_mapping[friend], friend_config=friend
-                )
-            )
-        return requirements
-
     def create_branch_map(self):
         return [{"era": self.era, "sample_type": self.sample_type}]
 
@@ -63,16 +52,16 @@ class FriendQuantitiesMap(law.LocalWorkflow, Task):
         quantities_map[era] = {}
         quantities_map[era][sample_type] = {}
         # go through all input files and get all quantities maps
-        samples = self.input()["ntuples"]
+        samples = self.workflow_input()["ntuples"]
         for sample in samples:
             if isinstance(
-                self.input()["ntuples"][sample], law.NestedSiblingFileCollection
+                self.workflow_input()["ntuples"][sample], law.NestedSiblingFileCollection
             ):
-                inputfiles = self.input()["ntuples"][sample]._flat_target_list
+                inputfiles = self.workflow_input()["ntuples"][sample]._flat_target_list
                 # add all friend files to the inputfiles list
                 for friend in self.friend_mapping:
                     inputfiles.extend(
-                        self.input()[
+                        self.workflow_input()[
                             f"CROWNFriends_{self.nick}_{self.friend_mapping[friend]}"
                         ][sample]._flat_target_list
                     )

--- a/processor/tasks/QuantitiesMap.py
+++ b/processor/tasks/QuantitiesMap.py
@@ -33,7 +33,6 @@ class QuantitiesMap(law.LocalWorkflow, Task):
         target = self.remote_target(
             f"{self.production_tag}/{self.era}_{'-'.join(list(self.scopes))}_{self.sample_type}_quantities_map.json".format()
         )
-        target.parent.touch()
         return target
 
     def run(self):

--- a/processor/tasks/QuantitiesMap.py
+++ b/processor/tasks/QuantitiesMap.py
@@ -21,11 +21,6 @@ class QuantitiesMap(law.LocalWorkflow, Task):
         requirements["ntuples"] = CROWNRun.req(self)
         return requirements
 
-    def requires(self):
-        requirements = {}
-        requirements["ntuples"] = CROWNRun.req(self)
-        return requirements
-
     def create_branch_map(self):
         return {
             0: {
@@ -52,12 +47,12 @@ class QuantitiesMap(law.LocalWorkflow, Task):
         quantities_map[era] = {}
         quantities_map[era][sample_type] = {}
         # go through all input files and get all quantities maps
-        inputs = self.input()["ntuples"]
+        inputs = self.workflow_input()["ntuples"]
         for sample in inputs:
             if isinstance(
-                self.input()["ntuples"][sample], law.NestedSiblingFileCollection
+                self.workflow_input()["ntuples"][sample], law.NestedSiblingFileCollection
             ):
-                inputfiles = self.input()["ntuples"][sample]._flat_target_list
+                inputfiles = self.workflow_input()["ntuples"][sample]._flat_target_list
                 for inputfile in inputfiles:
                     if inputfile.path.endswith("quantities_map.json"):
                         with inputfile.localize("r") as _file:

--- a/processor/tasks/QuantitiesMap.py
+++ b/processor/tasks/QuantitiesMap.py
@@ -47,13 +47,13 @@ class QuantitiesMap(law.LocalWorkflow, Task):
         quantities_map[era] = {}
         quantities_map[era][sample_type] = {}
         # go through all input files and get all quantities maps
-        inputs = self.workflow_input()["ntuples"]
-        for sample in inputs:
+        inputs = self.workflow_input()
+        for sample in inputs["ntuples"]:
             if isinstance(
-                self.workflow_input()["ntuples"][sample],
+                inputs["ntuples"][sample],
                 law.NestedSiblingFileCollection,
             ):
-                inputfiles = self.workflow_input()["ntuples"][sample]._flat_target_list
+                inputfiles = inputs["ntuples"][sample]._flat_target_list
                 for inputfile in inputfiles:
                     if inputfile.path.endswith("quantities_map.json"):
                         with inputfile.localize("r") as _file:

--- a/processor/tasks/QuantitiesMap.py
+++ b/processor/tasks/QuantitiesMap.py
@@ -50,7 +50,8 @@ class QuantitiesMap(law.LocalWorkflow, Task):
         inputs = self.workflow_input()["ntuples"]
         for sample in inputs:
             if isinstance(
-                self.workflow_input()["ntuples"][sample], law.NestedSiblingFileCollection
+                self.workflow_input()["ntuples"][sample],
+                law.NestedSiblingFileCollection,
             ):
                 inputfiles = self.workflow_input()["ntuples"][sample]._flat_target_list
                 for inputfile in inputfiles:


### PR DESCRIPTION
This PR updates our workflows to reduce the amount of dcache accesses. Main changes are
* move to `workflow_requires()` where possible
* remove `target.parent.touch()` calls everywhere because this is normally taken care of by law already
* have only one `input()` call per task (not sure if this results in any change)

In a test run the dcache accesses were reduced by over 3 times.