### PR TITLE
HTCondor log files path

### DIFF
--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -76,7 +76,7 @@ shifts = None
 [CROWNRun]
 ; HTCondor
 htcondor_walltime = 10800
-htcondor_request_memory = 10000
+htcondor_request_memory = 16000
 htcondor_request_disk = 20000000
 ; for these eras, only one file per task is processed
 problematic_eras = ["2018B", "2017C", "2016B-ver2"]
@@ -84,7 +84,7 @@ problematic_eras = ["2018B", "2017C", "2016B-ver2"]
 [CROWNFriends]
 ; HTCondor
 htcondor_walltime = 10800
-htcondor_request_memory = 10000
+htcondor_request_memory = 16000
 htcondor_request_disk = 20000000
 ; friends have to be run in single core mode to ensure a correct order of the tree entries
 htcondor_request_cpus = 1

--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -6,7 +6,7 @@ log_level = WARNING
 keep_alive = False
 ping_interval = 20
 wait_interval = 20
-max_reschedules = 10
+max_reschedules = 2
 
 [DEFAULT]
 name = KingMaker
@@ -76,7 +76,7 @@ shifts = None
 [CROWNRun]
 ; HTCondor
 htcondor_walltime = 10800
-htcondor_request_memory = 16000
+htcondor_request_memory = 10000
 htcondor_request_disk = 20000000
 ; for these eras, only one file per task is processed
 problematic_eras = ["2018B", "2017C", "2016B-ver2"]
@@ -84,7 +84,7 @@ problematic_eras = ["2018B", "2017C", "2016B-ver2"]
 [CROWNFriends]
 ; HTCondor
 htcondor_walltime = 10800
-htcondor_request_memory = 16000
+htcondor_request_memory = 10000
 htcondor_request_disk = 20000000
 ; friends have to be run in single core mode to ensure a correct order of the tree entries
 htcondor_request_cpus = 1

--- a/processor/tasks/CROWNBase.py
+++ b/processor/tasks/CROWNBase.py
@@ -11,6 +11,9 @@ from helpers.helpers import convert_to_comma_seperated
 import hashlib
 import time
 
+# Determine KingMaker base directory dynamically from this file's location
+KINGMAKER_BASE = os.path.normpath(os.path.join(os.path.dirname(__file__), "../.."))
+
 
 class ProduceBase(Task, WrapperTask):
     """
@@ -154,7 +157,25 @@ class CROWNExecuteBase(HTCondorWorkflow, law.LocalWorkflow):
     files_per_task = luigi.IntParameter()
 
     def htcondor_output_directory(self):
-        return law.LocalDirectoryTarget(self.local_path(f"htcondor_files/{self.nick}"))
+        path = os.path.join(
+            KINGMAKER_BASE,
+            "data",
+            self.production_tag,
+            "htcondor_files",
+            "ntuples",
+            self.nick
+        )
+        class_name = self.__class__.__name__
+        if "Friend" in class_name:
+             path = os.path.join(
+                KINGMAKER_BASE,
+                "data",
+                self.production_tag,
+                "htcondor_files",
+                self.friend_name,
+                self.nick
+            )
+        return law.LocalDirectoryTarget(path)
 
     def htcondor_job_config(self, config, job_num, branches):
         class_name = self.__class__.__name__

--- a/processor/tasks/CROWNBase.py
+++ b/processor/tasks/CROWNBase.py
@@ -167,7 +167,7 @@ class CROWNExecuteBase(HTCondorWorkflow, law.LocalWorkflow):
         )
         class_name = self.__class__.__name__
         if "Friend" in class_name:
-             path = os.path.join(
+            path = os.path.join(
                 KINGMAKER_BASE,
                 "data",
                 self.production_tag,

--- a/processor/tasks/CROWNBase.py
+++ b/processor/tasks/CROWNBase.py
@@ -163,7 +163,7 @@ class CROWNExecuteBase(HTCondorWorkflow, law.LocalWorkflow):
             self.production_tag,
             "htcondor_files",
             "ntuples",
-            self.nick
+            self.nick,
         )
         class_name = self.__class__.__name__
         if "Friend" in class_name:
@@ -173,7 +173,7 @@ class CROWNExecuteBase(HTCondorWorkflow, law.LocalWorkflow):
                 self.production_tag,
                 "htcondor_files",
                 self.friend_name,
-                self.nick
+                self.nick,
             )
         return law.LocalDirectoryTarget(path)
 

--- a/processor/tasks/scripts/compile_crown.sh
+++ b/processor/tasks/scripts/compile_crown.sh
@@ -13,7 +13,7 @@ EXECUTABLE_THREADS=${11}
 # setup with analysis clone if needed
 set -o pipefail
 set -e
-source ${CROWNFOLDER}/init.sh ${ANALYSIS}
+source ${ANALYSIS_PATH}/CROWN/init.sh ${ANALYSIS}
 # remove conda prefix from $PATH so cmakes uses the LCG stack python and not the conda one
 if [[ ! -z "${CONDA_PREFIX}" ]]; then
 	PATH=$(echo ${PATH} | sed "s@${CONDA_PREFIX}@@g")

--- a/processor/tasks/scripts/compile_crown.sh
+++ b/processor/tasks/scripts/compile_crown.sh
@@ -13,7 +13,7 @@ EXECUTABLE_THREADS=${11}
 # setup with analysis clone if needed
 set -o pipefail
 set -e
-source ${ANALYSIS_PATH}/CROWN/init.sh ${ANALYSIS}
+source ${CROWNFOLDER}/init.sh ${ANALYSIS}
 # remove conda prefix from $PATH so cmakes uses the LCG stack python and not the conda one
 if [[ ! -z "${CONDA_PREFIX}" ]]; then
 	PATH=$(echo ${PATH} | sed "s@${CONDA_PREFIX}@@g")


### PR DESCRIPTION
The log files for HTCondor submission are now always stored in the directory of KingMaker, independently of where the ntuples are stored and processed. Memory requirements are lowered for optimal usage. The sample database is also updated.