### PR TITLE
Move get_alternate_file_uri from create_branch_map() into run()

### DIFF
--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -52,9 +52,6 @@ class CROWNRun(CROWNExecuteBase):
         for filecounter, filename in enumerate(inputdata["filelist"]):
             if (int(filecounter / files_per_task)) not in branches:
                 branches[int(filecounter / files_per_task)] = []
-            # This call aims to get a "better" XRootD server to access the file.
-            # If the file is available on GridKA, take it from there.
-            # Otherwise, use the official European or global redirector.
             branches[int(filecounter / files_per_task)].append(filename)
         for x in branches:
             branch_map[branchcounter] = {}
@@ -107,7 +104,9 @@ class CROWNRun(CROWNExecuteBase):
         _sample_type = branch_data["sample_type"]
         _era = branch_data["era"]
 
-        # Try to get 'better' redirector for input files
+        # This call aims to get a "better" XRootD server to access the file.
+        # If the file is available on GridKA, take it from there.
+        # Otherwise, use the official European or global redirector.
         _inputfiles = [
             get_alternate_file_uri(
                 filename,

--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -55,14 +55,6 @@ class CROWNRun(CROWNExecuteBase):
             # This call aims to get a "better" XRootD server to access the file.
             # If the file is available on GridKA, take it from there.
             # Otherwise, use the official European or global redirector.
-            filename = get_alternate_file_uri(
-                filename,
-                [
-                    "root://cmsdcache-kit-disk.gridka.de",
-                    "root://xrootd-cms.infn.it",
-                    "root://cms-xrd-global.cern.ch",
-                ],
-            )
             branches[int(filecounter / files_per_task)].append(filename)
         for x in branches:
             branch_map[branchcounter] = {}
@@ -114,6 +106,20 @@ class CROWNRun(CROWNExecuteBase):
         _inputfiles = branch_data["files"]
         _sample_type = branch_data["sample_type"]
         _era = branch_data["era"]
+
+        # Try to get 'better' redirector for input files
+        _inputfiles = [
+            get_alternate_file_uri(
+                filename,
+                [
+                    "root://cmsdcache-kit-disk.gridka.de",
+                    "root://xrootd-cms.infn.it",
+                    "root://cms-xrd-global.cern.ch",
+                ],
+            )
+            for filename in _inputfiles
+        ]
+
         # set the outputfilename to the first name in the output list, removing the scope suffix
         _outputfile = str(
             rootfile_outputs[0].basename.replace(


### PR DESCRIPTION
The `get_alternate_uri` function has been introduced with pull request https://github.com/KIT-CMS/KingMaker/pull/73 to find an URI, under which a NANOAOD file is accessible. The function has been executed in the `create_branch_map` method of `CROWNRun`, causing `stat` operations to be issued every time when `create_branch_map` is called for every NANOAOD file in the respective sample lists, even if the `ntuple` files are already present.

The execution of the `get_alternate_uri` function has been moved to `run()`. Now, the check for the existence of a NANOAOD file is only checked if the NANOAOD -> ntuple step is actually performed, i.e., only once when actually running the processing.