### PR TITLE
Option to force update tarballs

### DIFF
--- a/lawluigi_configs/KingMaker_law.cfg
+++ b/lawluigi_configs/KingMaker_law.cfg
@@ -14,9 +14,12 @@ ProduceMultiFriends
 ProduceSamples
 QuantitiesMap
 
-# [logging]
+[logging]
 # law: DEBUG
 # luigi-interface: DEBUG
+# gfal2: DEBUG
+# xrootd: DEBUG
+# processor.helpers.helpers: DEBUG
 
 [luigi_worker]
 keep_alive: True

--- a/lawluigi_configs/KingMaker_law.cfg
+++ b/lawluigi_configs/KingMaker_law.cfg
@@ -18,8 +18,7 @@ QuantitiesMap
 # law: DEBUG
 # luigi-interface: DEBUG
 # gfal2: DEBUG
-# xrootd: DEBUG
-# processor.helpers.helpers: DEBUG
+# xrootd.stat: DEBUG
 
 [luigi_worker]
 keep_alive: True

--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -61,10 +61,6 @@ shifts = None
 ; different runs of the workflow, and the tarball is already present in the cache. In this case, setting this parameter to True will force the repacking of the tarball, even if it is already present in the cache. 
 force_repack_tarball = False
 
-; Set to True to enable tracing of XRootD stat calls with their call site in remote jobs.
-; Useful for debugging excessive or unexpected XRootD stat calls.
-trace_xrd_stat = False
-
 ###################################################  NOTE  #####################################################
 # Parameters of tasks that were not explicitly called in the cli will be set through the 'requires' functions. #
 # Only parameters that are listed in 'exclude_params_req' are excluded from this.                              #

--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -61,6 +61,10 @@ shifts = None
 ; different runs of the workflow, and the tarball is already present in the cache. In this case, setting this parameter to True will force the repacking of the tarball, even if it is already present in the cache. 
 force_repack_tarball = False
 
+; Set to True to enable tracing of XRootD stat calls with their call site in remote jobs.
+; Useful for debugging excessive or unexpected XRootD stat calls.
+trace_xrd_stat = False
+
 ###################################################  NOTE  #####################################################
 # Parameters of tasks that were not explicitly called in the cli will be set through the 'requires' functions. #
 # Only parameters that are listed in 'exclude_params_req' are excluded from this.                              #

--- a/lawluigi_configs/KingMaker_luigi.cfg
+++ b/lawluigi_configs/KingMaker_luigi.cfg
@@ -56,6 +56,11 @@ files_per_task = 10
 scopes = mt,et
 shifts = None
 
+; Only set this parameter to True if the tarball with the law tasks needs to
+; be repacked. This might be needed if task code significantly changed between 
+; different runs of the workflow, and the tarball is already present in the cache. In this case, setting this parameter to True will force the repacking of the tarball, even if it is already present in the cache. 
+force_repack_tarball = False
+
 ###################################################  NOTE  #####################################################
 # Parameters of tasks that were not explicitly called in the cli will be set through the 'requires' functions. #
 # Only parameters that are listed in 'exclude_params_req' are excluded from this.                              #

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -327,11 +327,16 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         default="source /opt/conda/bin/activate env",
         significant=False,
     )
+    force_repack_tarball = luigi.BoolParameter(
+        default=False,
+        description="Force repacking and re-uploading of the job tarball, even if it already exists remotely. Use this after updating task code without removing task outputs.",
+        significant=False,
+    )
 
     # Use proxy file located in $X509_USER_PROXY or /tmp/x509up_u$(id) if empty
     htcondor_user_proxy = law.wlcg.get_vomsproxy_file()
 
-    # Do not propagate certain parameters via the ".req()" methode
+    # Do not propagate certain parameters via the ".req()" method
     exclude_set = {
         "ENV_NAME",
         "htcondor_requirements",
@@ -344,6 +349,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         "htcondor_universe",
         "htcondor_docker_image",
         "additional_files",
+        "force_repack_tarball",
         "workflow",
     }
     exclude_params_req = (
@@ -508,7 +514,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
                     "processor.tar.gz",
                 )
             )
-        if not tarball.exists():
+        if not tarball.exists() or self.force_repack_tarball:
             # Make new tarball
             # get absolute path to tarball dir
             tarball_dir = os.path.abspath(f"tarballs/{self.production_tag}")
@@ -524,7 +530,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
             )
             tarball_local.parent.touch()
             # Create tarball containing:
-            #   The processor directory, thhe relevant config files, law
+            #   The processor directory, the relevant config files, law
             #   and any other files specified in the additional_files parameter
             command = [
                 "tar",

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -332,11 +332,6 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         description="Force repacking and re-uploading of the job tarball, even if it already exists remotely. Use this after updating task code without removing task outputs.",
         significant=False,
     )
-    trace_xrd_stat = luigi.BoolParameter(
-        default=False,
-        description="Enable tracing of XRootD stat calls with their call site. Sets TRACE_XRD_STAT=1 in remote jobs.",
-        significant=False,
-    )
 
     # Use proxy file located in $X509_USER_PROXY or /tmp/x509up_u$(id) if empty
     htcondor_user_proxy = law.wlcg.get_vomsproxy_file()
@@ -355,7 +350,6 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         "htcondor_docker_image",
         "additional_files",
         "force_repack_tarball",
-        "trace_xrd_stat",
         "workflow",
     }
     exclude_params_req = (
@@ -589,7 +583,6 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
             )
         config.render_variables["LOCAL_TIMESTAMP"] = startup_time
         config.render_variables["LOCAL_PWD"] = startup_dir
-        config.render_variables["TRACE_XRD_STAT"] = "1" if self.trace_xrd_stat else ""
         # only needed for $ANA_NAME=ML_train see setup.sh line 207
         if os.getenv("MODULE_PYTHONPATH"):
             config.render_variables["MODULE_PYTHONPATH"] = os.getenv(

--- a/processor/framework.py
+++ b/processor/framework.py
@@ -332,6 +332,11 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         description="Force repacking and re-uploading of the job tarball, even if it already exists remotely. Use this after updating task code without removing task outputs.",
         significant=False,
     )
+    trace_xrd_stat = luigi.BoolParameter(
+        default=False,
+        description="Enable tracing of XRootD stat calls with their call site. Sets TRACE_XRD_STAT=1 in remote jobs.",
+        significant=False,
+    )
 
     # Use proxy file located in $X509_USER_PROXY or /tmp/x509up_u$(id) if empty
     htcondor_user_proxy = law.wlcg.get_vomsproxy_file()
@@ -350,6 +355,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
         "htcondor_docker_image",
         "additional_files",
         "force_repack_tarball",
+        "trace_xrd_stat",
         "workflow",
     }
     exclude_params_req = (
@@ -583,6 +589,7 @@ class HTCondorWorkflow(Task, law.htcondor.HTCondorWorkflow):
             )
         config.render_variables["LOCAL_TIMESTAMP"] = startup_time
         config.render_variables["LOCAL_PWD"] = startup_dir
+        config.render_variables["TRACE_XRD_STAT"] = "1" if self.trace_xrd_stat else ""
         # only needed for $ANA_NAME=ML_train see setup.sh line 207
         if os.getenv("MODULE_PYTHONPATH"):
             config.render_variables["MODULE_PYTHONPATH"] = os.getenv(

--- a/processor/setup_law_remote.sh
+++ b/processor/setup_law_remote.sh
@@ -22,7 +22,6 @@ action() {
     # if no XRD_LOGLEVEL set: no xrootd debug output written
     # set export XRD_LOGLEVEL=Debug for xrootd debug output
     export XRD_LOGLEVEL=""
-    export TRACE_XRD_STAT="{{TRACE_XRD_STAT}}"
     if [[ -n "${XRD_LOGLEVEL}" ]]; then
         export XRD_LOGFILE=${SPAWNPOINT}/xrd_error_log.log
         echo "XRD_LOGLEVEL variable set to ${XRD_LOGLEVEL}: XRD_LOGFILE will be stored at ${XRD_LOGFILE}"

--- a/processor/setup_law_remote.sh
+++ b/processor/setup_law_remote.sh
@@ -22,6 +22,7 @@ action() {
     # if no XRD_LOGLEVEL set: no xrootd debug output written
     # set export XRD_LOGLEVEL=Debug for xrootd debug output
     export XRD_LOGLEVEL=""
+    export TRACE_XRD_STAT="{{TRACE_XRD_STAT}}"
     if [[ -n "${XRD_LOGLEVEL}" ]]; then
         export XRD_LOGFILE=${SPAWNPOINT}/xrd_error_log.log
         echo "XRD_LOGLEVEL variable set to ${XRD_LOGLEVEL}: XRD_LOGFILE will be stored at ${XRD_LOGFILE}"

--- a/processor/tasks/CROWNRun.py
+++ b/processor/tasks/CROWNRun.py
@@ -37,7 +37,8 @@ class CROWNRun(CROWNExecuteBase):
         branchcounter = 0
         dataset = ConfigureDatasets.req(self)
         # since we use the filelist from the dataset, we need to run it first
-        dataset.run()
+        if not dataset.complete():
+            dataset.run()
         datsetinfo = dataset.output()
         with datsetinfo.localize("r") as _file:
             inputdata = _file.load()

--- a/processor/tasks/helpers/helpers.py
+++ b/processor/tasks/helpers/helpers.py
@@ -2,18 +2,23 @@ from functools import cache
 import os
 import re
 import traceback
+import logging
+from law.logger import get_logger
 from XRootD.client import FileSystem
 from XRootD.client.flags import StatInfoFlags
 
+
+# Get law loggers for this module
+logger_xrootd = get_logger("xrootd")
 # Patch FileSystem.stat to trace all XRootD stat calls with their call site.
 # Only active when TRACE_XRD_STAT=1 is set at call time.
 _original_fs_stat = FileSystem.stat
 
 
 def _traced_fs_stat(self, path, *args, **kwargs):
-    if os.environ.get("TRACE_XRD_STAT") == "1":
-        print(f"[XRootD STAT] {self.url}{path}", flush=True)
-        traceback.print_stack(limit=6)
+    if logger_xrootd.isEnabledFor(logging.DEBUG):
+        logger_xrootd.debug(f"[XRootD STAT] {self.url}{path}")
+        logger_xrootd.debug("".join(traceback.format_stack(limit=6)))
     return _original_fs_stat(self, path, *args, **kwargs)
 
 

--- a/processor/tasks/helpers/helpers.py
+++ b/processor/tasks/helpers/helpers.py
@@ -10,6 +10,9 @@ from XRootD.client.flags import StatInfoFlags
 
 # Get law loggers for this module
 logger_xrootd = get_logger("xrootd")
+logger_helpers = get_logger("processor.helpers.helpers")
+
+
 # Patch FileSystem.stat to trace all XRootD stat calls with their call site.
 # Only active when TRACE_XRD_STAT=1 is set at call time.
 _original_fs_stat = FileSystem.stat
@@ -114,11 +117,12 @@ def get_alternate_file_uri(
 
     :returns: The final file name.
     """
+    logger_helpers.debug(f"find alternative location for file {file}, test servers {xrootd_servers}")
 
     # Check whether the file fulfills the pattern of a usual XRootD file path.
     # If not, just return the file without modifying the path. Otherwise,
     # extract the file path without the server address.
-    m = re.match(r"^(root://[^/]+)/+(.+)$", file)
+    m = re.match(r"^((root|davs)://[^/]+)/+(.+)$", file)
     if m is None:
         return file
     path = f"/{m.group(2).rstrip('/')}"

--- a/processor/tasks/helpers/helpers.py
+++ b/processor/tasks/helpers/helpers.py
@@ -6,12 +6,12 @@ from XRootD.client import FileSystem
 from XRootD.client.flags import StatInfoFlags
 
 # Patch FileSystem.stat to trace all XRootD stat calls with their call site.
-# Only active when XRD_LOGLEVEL=Debug is set at call time.
+# Only active when TRACE_XRD_STAT=1 is set at call time.
 _original_fs_stat = FileSystem.stat
 
 
 def _traced_fs_stat(self, path, *args, **kwargs):
-    if os.environ.get("XRD_LOGLEVEL", "").lower() == "debug":
+    if os.environ.get("TRACE_XRD_STAT") == "1":
         print(f"[XRootD STAT] {self.url}{path}", flush=True)
         traceback.print_stack(limit=6)
     return _original_fs_stat(self, path, *args, **kwargs)

--- a/processor/tasks/helpers/helpers.py
+++ b/processor/tasks/helpers/helpers.py
@@ -9,11 +9,13 @@ from XRootD.client.flags import StatInfoFlags
 # Only active when XRD_LOGLEVEL=Debug is set at call time.
 _original_fs_stat = FileSystem.stat
 
+
 def _traced_fs_stat(self, path, *args, **kwargs):
     if os.environ.get("XRD_LOGLEVEL", "").lower() == "debug":
         print(f"[XRootD STAT] {self.url}{path}", flush=True)
         traceback.print_stack(limit=6)
     return _original_fs_stat(self, path, *args, **kwargs)
+
 
 FileSystem.stat = _traced_fs_stat
 

--- a/processor/tasks/helpers/helpers.py
+++ b/processor/tasks/helpers/helpers.py
@@ -117,7 +117,9 @@ def get_alternate_file_uri(
 
     :returns: The final file name.
     """
-    logger_helpers.debug(f"find alternative location for file {file}, test servers {xrootd_servers}")
+    logger_helpers.debug(
+        f"find alternative location for file {file}, test servers {xrootd_servers}"
+    )
 
     # Check whether the file fulfills the pattern of a usual XRootD file path.
     # If not, just return the file without modifying the path. Otherwise,

--- a/processor/tasks/helpers/helpers.py
+++ b/processor/tasks/helpers/helpers.py
@@ -9,8 +9,7 @@ from XRootD.client.flags import StatInfoFlags
 
 
 # Get law loggers for this module
-logger_xrootd = get_logger("xrootd")
-logger_helpers = get_logger("processor.helpers.helpers")
+logger = get_logger("xrootd.stat")
 
 
 # Patch FileSystem.stat to trace all XRootD stat calls with their call site.
@@ -19,9 +18,9 @@ _original_fs_stat = FileSystem.stat
 
 
 def _traced_fs_stat(self, path, *args, **kwargs):
-    if logger_xrootd.isEnabledFor(logging.DEBUG):
-        logger_xrootd.debug(f"[XRootD STAT] {self.url}{path}")
-        logger_xrootd.debug("".join(traceback.format_stack(limit=6)))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"[XRootD STAT] {self.url}{path}")
+        logger.debug("".join(traceback.format_stack(limit=6)))
     return _original_fs_stat(self, path, *args, **kwargs)
 
 
@@ -117,9 +116,6 @@ def get_alternate_file_uri(
 
     :returns: The final file name.
     """
-    logger_helpers.debug(
-        f"find alternative location for file {file}, test servers {xrootd_servers}"
-    )
 
     # Check whether the file fulfills the pattern of a usual XRootD file path.
     # If not, just return the file without modifying the path. Otherwise,
@@ -127,7 +123,7 @@ def get_alternate_file_uri(
     m = re.match(r"^((root|davs)://[^/]+)/+(.+)$", file)
     if m is None:
         return file
-    path = f"/{m.group(2).rstrip('/')}"
+    path = f"/{m.group(3).rstrip('/')}"
 
     # Cycle through the given XRootD servers and check if the file exists
     # there. Return the first one that is found. If no file is found on the

--- a/processor/tasks/helpers/helpers.py
+++ b/processor/tasks/helpers/helpers.py
@@ -1,8 +1,21 @@
 from functools import cache
 import os
 import re
+import traceback
 from XRootD.client import FileSystem
 from XRootD.client.flags import StatInfoFlags
+
+# Patch FileSystem.stat to trace all XRootD stat calls with their call site.
+# Only active when XRD_LOGLEVEL=Debug is set at call time.
+_original_fs_stat = FileSystem.stat
+
+def _traced_fs_stat(self, path, *args, **kwargs):
+    if os.environ.get("XRD_LOGLEVEL", "").lower() == "debug":
+        print(f"[XRootD STAT] {self.url}{path}", flush=True)
+        traceback.print_stack(limit=6)
+    return _original_fs_stat(self, path, *args, **kwargs)
+
+FileSystem.stat = _traced_fs_stat
 
 
 def convert_to_comma_seperated(listobject):


### PR DESCRIPTION
This PR introduces a parameter that forces to build and upload the `processor.tar.gz` file which is usually created only once.
This can be need if the law tasks code changes significantly and a user wants to update the code base that is run within the jobs between workflow tasks. 

Example: run `ProduceSamples` with old code -> run `ProduceFriends` with new code


Additionally, a feature is added to track stat request done by xrootd. This will trigger as long as the parameter `trace_xrd_stat` is set to `True` in the luigi config.